### PR TITLE
Final update for 3.02

### DIFF
--- a/ADDS_Inventory_V3.ps1
+++ b/ADDS_Inventory_V3.ps1
@@ -54,49 +54,18 @@
 	
 	To run the script from a workstation, RSAT is required.
 	
+	Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)
+		https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24
+		
 	Remote Server Administration Tools for Windows 8 
-		http://www.microsoft.com/en-us/download/details.aspx?id=28972
+		https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95
 		
 	Remote Server Administration Tools for Windows 8.1 
-		http://www.microsoft.com/en-us/download/details.aspx?id=39296
+		https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226
 		
 	Remote Server Administration Tools for Windows 10
 		http://www.microsoft.com/en-us/download/details.aspx?id=45520
 	
-.PARAMETER HTML
-	Creates an HTML file with an .html extension.
-	
-	HTML is now the default report format.
-	
-	This parameter is set True if no other output format is selected.
-.PARAMETER MSWord
-	SaveAs DOCX file
-	
-	Microsoft Word is no longer the default report format.
-	This parameter is disabled by default.
-.PARAMETER PDF
-	SaveAs PDF file instead of DOCX file.
-	
-	The PDF file is roughly 5X to 10X larger than the DOCX file.
-	
-	This parameter requires Microsoft Word to be installed.
-	This parameter uses Word's SaveAs PDF capability.
-
-	This parameter is disabled by default.
-.PARAMETER Text
-	Creates a formatted text file with a .txt extension.
-	
-	This parameter is disabled by default.
-.PARAMETER AddDateTime
-	Adds a date timestamp to the end of the file name.
-	
-	The timestamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2020 at 6PM is 2020-06-01_1800.
-	
-	Output filename will be ReportName_2020-06-01_1800.docx (or .pdf).
-	
-	This parameter is disabled by default.
-	This parameter has an alias of ADT.
 .PARAMETER ADDomain
 	Specifies an Active Directory domain object by providing one of the following 
 	property values. The identifier in parentheses is the LDAP display name for the 
@@ -140,6 +109,156 @@
 	Default value is $Env:USERDNSDOMAIN	
 	
 	If both ADForest and ADDomain are specified, ADDomain takes precedence.
+.PARAMETER ComputerName
+	Specifies which domain controller to use to run the script against.
+	If ADForest is a trusted forest, then ComputerName is required to detect the 
+	existence of ADForest.
+	ComputerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
+	If entered as localhost, the actual computer name is determined and used.
+	If entered as an IP address, an attempt is made to determine and use the actual 
+	computer name.
+	
+	This parameter has an alias of ServerName.
+	Default value is $Env:USERDNSDOMAIN	
+.PARAMETER MaxDetails
+	Adds maximum detail to the report.
+	
+	This is the same as using the following parameters:
+		DCDNSInfo
+		GPOInheritance
+		Hardware
+		IncludeUserInfo
+		Services
+	
+	WARNING: Using this parameter can create an extremely large report and 
+	can take a very long time to run.
+
+	This parameter has an alias of MAX.
+.PARAMETER HTML
+	Creates an HTML file with an .html extension.
+	
+	HTML is now the default report format.
+	
+	This parameter is set True if no other output format is selected.
+.PARAMETER Text
+	Creates a formatted text file with a .txt extension.
+	
+	This parameter is disabled by default.
+.PARAMETER AddDateTime
+	Adds a date timestamp to the end of the file name.
+	
+	The timestamp is in the format of yyyy-MM-dd_HHmm.
+	June 1, 2021 at 6PM is 2021-06-01_1800.
+	
+	Output filename will be ReportName_2021-06-01_1800.docx (or .pdf).
+	
+	This parameter is disabled by default.
+	This parameter has an alias of ADT.
+.PARAMETER Dev
+	Clears errors at the beginning of the script.
+	Outputs all errors to a text file at the end of the script.
+	
+	This is used when the script developer requests more troubleshooting data.
+	The text file is placed in the same folder from where the script is run.
+	
+	This parameter is disabled by default.
+.PARAMETER Folder
+	Specifies the optional output folder to save the output report. 
+.PARAMETER Log
+	Generates a log file for troubleshooting.
+.PARAMETER ScriptInfo
+	Outputs information about the script to a text file.
+	The text file is placed in the same folder from where the script is run.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of SI.
+.PARAMETER DCDNSInfo 
+	Use WMI to gather, for each domain controller, the IP Address, and each DNS server 
+	configured.
+	This parameter requires the script be run from an elevated PowerShell session 
+	using an account with permission to retrieve hardware information (i.e. Domain 
+	Admin).
+	Selecting this parameter will add an extra section to the report.
+	This parameter is disabled by default.
+.PARAMETER GPOInheritance
+	In the Group Policies by OU section, adds Inherited GPOs in addition to the GPOs 
+	directly linked.
+	Adds a second column to the table GPO Type.
+	The text file is placed in the same folder from where the script is run.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of GPO.
+.PARAMETER Hardware
+	Use WMI to gather hardware information on Computer System, Disks, Processor, and 
+	Network Interface Cards
+	This parameter requires the script be run from an elevated PowerShell session 
+	using an account with permission to retrieve hardware information (i.e. Domain 
+	Admin).
+	Selecting this parameter will add to both the time it takes to run the script and 
+	size of the report.
+	This parameter is disabled by default.
+.PARAMETER IncludeUserInfo
+	For the User Miscellaneous Data section outputs a table with the SamAccountName
+	and DistinguishedName of the users in the All Users counts:
+	
+		Disabled users
+		Unknown users
+		Locked out users
+		All users with password expired
+		All users whose password never expires
+		All users with password not required
+		All users who cannot change password
+		All users with SID History
+		All users with Homedrive set in ADUC
+		All users whose Primary Group is not Domain Users
+		All users with RDS HomeDrive set in ADUC
+	
+	The Text output option is limited to the first 25 characters of the SamAccountName
+	and the first 116 characters of the DistinguishedName.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of IU.
+.PARAMETER Section
+	Processes one or more sections of the report.
+	Valid options are:
+		Forest
+		Sites
+		Domains (includes Domain Controllers and optional Hardware, Services and 
+		DCDNSInfo)
+		OUs (Organizational Units)
+		Groups
+		GPOs
+		Misc (Miscellaneous data)
+		All
+
+	This parameter defaults to All sections.
+	
+	Multiple sections are separated by a comma. -Section forest, domains
+.PARAMETER Services
+	Gather information on all services running on domain controllers.
+	Servers that are configured to automatically start but are not running will be 
+	colored in red.
+	Used on Domain Controllers only.
+	This parameter requires the script be run from an elevated PowerShell session
+	using an account with permission to retrieve service information (i.e. Domain 
+	Admin).
+	Selecting this parameter will add to both the time it takes to run the script and 
+	size of the report.
+	This parameter is disabled by default.
+.PARAMETER MSWord
+	SaveAs DOCX file
+	
+	Microsoft Word is no longer the default report format.
+	This parameter is disabled by default.
+.PARAMETER PDF
+	SaveAs PDF file instead of DOCX file.
+	
+	The PDF file is roughly 5X to 10X larger than the DOCX file.
+	
+	This parameter requires Microsoft Word to be installed.
+	This parameter uses Word's SaveAs PDF capability.
+
+	This parameter is disabled by default.
 .PARAMETER CompanyAddress
 	Company Address to use for the Cover Page, if the Cover Page has the Address field.
 	
@@ -192,17 +311,6 @@
 	
 	This parameter is only valid with the MSWORD and PDF output parameters.
 	This parameter has an alias of CPh.
-.PARAMETER ComputerName
-	Specifies which domain controller to use to run the script against.
-	If ADForest is a trusted forest, then ComputerName is required to detect the 
-	existence of ADForest.
-	ComputerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
-	If entered as localhost, the actual computer name is determined and used.
-	If entered as an IP address, an attempt is made to determine and use the actual 
-	computer name.
-	
-	This parameter has an alias of ServerName.
-	Default value is $Env:USERDNSDOMAIN	
 .PARAMETER CoverPage
 	What Microsoft Word Cover Page to use.
 	Only Word 2010, 2013 and 2016 are supported.
@@ -251,115 +359,6 @@
 	The default value is Sideline.
 	This parameter has an alias of CP.
 	This parameter is only valid with the MSWORD and PDF output parameters.
-.PARAMETER DCDNSInfo 
-	Use WMI to gather, for each domain controller, the IP Address, and each DNS server 
-	configured.
-	This parameter requires the script be run from an elevated PowerShell session 
-	using an account with permission to retrieve hardware information (i.e. Domain 
-	Admin).
-	Selecting this parameter will add an extra section to the report.
-	This parameter is disabled by default.
-.PARAMETER Dev
-	Clears errors at the beginning of the script.
-	Outputs all errors to a text file at the end of the script.
-	
-	This is used when the script developer requests more troubleshooting data.
-	The text file is placed in the same folder from where the script is run.
-	
-	This parameter is disabled by default.
-.PARAMETER Folder
-	Specifies the optional output folder to save the output report. 
-.PARAMETER From
-	Specifies the username for the From email address.
-	
-	If SmtpServer or To are used, this is a required parameter.
-.PARAMETER GPOInheritance
-	In the Group Policies by OU section, adds Inherited GPOs in addition to the GPOs 
-	directly linked.
-	Adds a second column to the table GPO Type.
-	The text file is placed in the same folder from where the script is run.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of GPO.
-.PARAMETER Hardware
-	Use WMI to gather hardware information on Computer System, Disks, Processor, and 
-	Network Interface Cards
-	This parameter requires the script be run from an elevated PowerShell session 
-	using an account with permission to retrieve hardware information (i.e. Domain 
-	Admin).
-	Selecting this parameter will add to both the time it takes to run the script and 
-	size of the report.
-	This parameter is disabled by default.
-.PARAMETER IncludeUserInfo
-	For the User Miscellaneous Data section outputs a table with the SamAccountName
-	and DistinguishedName of the users in the All Users counts:
-	
-		Disabled users
-		Unknown users
-		Locked out users
-		All users with password expired
-		All users whose password never expires
-		All users with password not required
-		All users who cannot change password
-		All users with SID History
-		All users with Homedrive set in ADUC
-		All users whose Primary Group is not Domain Users
-		All users with RDS HomeDrive set in ADUC
-	
-	The Text output option is limited to the first 25 characters of the SamAccountName
-	and the first 116 characters of the DistinguishedName.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of IU.
-.PARAMETER Log
-	Generates a log file for troubleshooting.
-.PARAMETER MaxDetails
-	Adds maximum detail to the report.
-	
-	This is the same as using the following parameters:
-		DCDNSInfo
-		GPOInheritance
-		Hardware
-		IncludeUserInfo
-		Services
-	
-	WARNING: Using this parameter can create an extremely large report and 
-	can take a very long time to run.
-
-	This parameter has an alias of MAX.
-.PARAMETER ScriptInfo
-	Outputs information about the script to a text file.
-	The text file is placed in the same folder from where the script is run.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of SI.
-.PARAMETER Section
-	Processes one or more sections of the report.
-	Valid options are:
-		Forest
-		Sites
-		Domains (includes Domain Controllers and optional Hardware, Services and 
-		DCDNSInfo)
-		OUs (Organizational Units)
-		Groups
-		GPOs
-		Misc (Miscellaneous data)
-		All
-
-	This parameter defaults to All sections.
-	
-	Multiple sections are separated by a comma. -Section forest, domains
-.PARAMETER Services
-	Gather information on all services running on domain controllers.
-	Servers that are configured to automatically start but are not running will be 
-	colored in red.
-	Used on Domain Controllers only.
-	This parameter requires the script be run from an elevated PowerShell session
-	using an account with permission to retrieve service information (i.e. Domain 
-	Admin).
-	Selecting this parameter will add to both the time it takes to run the script and 
-	size of the report.
-	This parameter is disabled by default.
 .PARAMETER SmtpPort
 	Specifies the SMTP port for the SmtpServer. 
 
@@ -368,6 +367,10 @@
 	Specifies the optional email server to send the output report(s). 
 	
 	If From or To are used, this is a required parameter.
+.PARAMETER From
+	Specifies the username for the From email address.
+	
+	If SmtpServer or To are used, this is a required parameter.
 .PARAMETER To
 	Specifies the username for the To email address.
 	
@@ -615,8 +618,8 @@
 
 	Adds a date time stamp to the end of the file name.
 	The timestamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2020 at 6PM is 2020-06-01_1800.
-	Output filename will be company.tld_2020-06-01_1800.docx.
+	June 1, 2021 at 6PM is 2021-06-01_1800.
+	Output filename will be company.tld_2021-06-01_1800.docx.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com 
 	-AddDateTime
@@ -639,8 +642,8 @@
 
 	Adds a date time stamp to the end of the file name.
 	The timestamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2020 at 6PM is 2020-06-01_1800.
-	Output filename will be corp.carlwebster.com_2020-06-01_1800.PDF
+	June 1, 2021 at 6PM is 2021-06-01_1800.
+	Output filename will be corp.carlwebster.com_2021-06-01_1800.PDF
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -ADForest corp.carlwebster.com -Folder 
 	\\FileServer\ShareName
@@ -770,9 +773,9 @@
 	No objects are output from this script.  This script creates a Word or PDF document.
 .NOTES
 	NAME: ADDS_Inventory_V3.ps1
-	VERSION: 3.01
+	VERSION: 3.02
 	AUTHOR: Carl Webster and Michael B. Smith
-	LASTEDIT: October 12, 2020
+	LASTEDIT: January 9, 2021
 #>
 
 
@@ -781,13 +784,21 @@
 
 Param(
 	[parameter(Mandatory=$False)] 
+	[string]$ADDomain="", 
+
+	[parameter(Mandatory=$False)] 
+	[string]$ADForest=$Env:USERDNSDOMAIN, 
+
+	[parameter(Mandatory=$False)] 
+	[Alias("ServerName")]
+	[string]$ComputerName=$Env:USERDNSDOMAIN,
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("MAX")]
+	[Switch]$MaxDetails=$False,
+
+	[parameter(Mandatory=$False)] 
 	[Switch]$HTML=$False,
-
-	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
-	[Switch]$MSWord=$False,
-
-	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
-	[Switch]$PDF=$False,
 
 	[parameter(Mandatory=$False)] 
 	[Switch]$Text=$False,
@@ -797,10 +808,44 @@ Param(
 	[Switch]$AddDateTime=$False,
 	
 	[parameter(Mandatory=$False)] 
-	[string]$ADDomain="", 
+	[Switch]$Dev=$False,
+	
+	[parameter(Mandatory=$False)] 
+	[string]$Folder="",
+	
+	[parameter(Mandatory=$False)] 
+	[Switch]$Log=$False,
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("SI")]
+	[Switch]$ScriptInfo=$False,
 
 	[parameter(Mandatory=$False)] 
-	[string]$ADForest=$Env:USERDNSDOMAIN, 
+	[Switch]$DCDNSInfo=$False, 
+
+	[parameter(Mandatory=$False)] 
+	[Switch]$GPOInheritance=$False, 
+
+	[parameter(Mandatory=$False)] 
+	[Switch]$Hardware=$False, 
+
+	[parameter(Mandatory=$False)] 
+	[Alias("IU")]
+	[Switch]$IncludeUserInfo=$False,
+	
+	[Parameter( Mandatory = $False )]
+	[ValidateSet( 'Forest', 'Sites', 'Domains', 'OUs',
+		'Groups', 'GPOs', 'Misc', 'All' )]
+	[String[]] $Section = 'All',
+
+	[parameter(Mandatory=$False )] 
+	[Switch]$Services=$False,
+	
+	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
+	[Switch]$MSWord=$False,
+
+	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
+	[Switch]$PDF=$False,
 
 	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
 	[Alias("CA")]
@@ -827,56 +872,16 @@ Param(
 	[ValidateNotNullOrEmpty()]
 	[string]$CompanyPhone="",
     
-	[parameter(Mandatory=$False)] 
-	[Alias("ServerName")]
-	[string]$ComputerName=$Env:USERDNSDOMAIN,
-	
-	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
+	[parameter(ParameterSetName="WordPDF",Mandatory=$False)]
 	[Alias("CP")]
 	[ValidateNotNullOrEmpty()]
 	[string]$CoverPage="Sideline", 
 
-	[parameter(Mandatory=$False)] 
-	[Switch]$DCDNSInfo=$False, 
+	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
+	[Alias("UN")]
+	[ValidateNotNullOrEmpty()]
+	[string]$UserName=$env:username,
 
-	[parameter(Mandatory=$False)] 
-	[Switch]$Dev=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[string]$Folder="",
-	
-	[parameter(Mandatory=$False)] 
-	[string]$From="",
-
-	[parameter(Mandatory=$False)] 
-	[Switch]$GPOInheritance=$False, 
-
-	[parameter(Mandatory=$False)] 
-	[Switch]$Hardware=$False, 
-
-	[parameter(Mandatory=$False)] 
-	[Alias("IU")]
-	[Switch]$IncludeUserInfo=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[Switch]$Log=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("MAX")]
-	[Switch]$MaxDetails=$False,
-
-	[parameter(Mandatory=$False)] 
-	[Alias("SI")]
-	[Switch]$ScriptInfo=$False,
-
-	[Parameter( Mandatory = $False )]
-	[ValidateSet( 'Forest', 'Sites', 'Domains', 'OUs',
-		'Groups', 'GPOs', 'Misc', 'All' )]
-	[String[]] $Section = 'All',
-
-	[parameter(Mandatory=$False )] 
-	[Switch]$Services=$False,
-	
 	[parameter(Mandatory=$False)] 
 	[int]$SmtpPort=25,
 
@@ -887,15 +892,13 @@ Param(
 	[Switch]$SuperVerbose = $false,
 	
 	[parameter(Mandatory=$False)] 
-	[string]$To="",
-
-	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
-	[Alias("UN")]
-	[ValidateNotNullOrEmpty()]
-	[string]$UserName=$env:username,
+	[string]$From="",
 
 	[parameter(Mandatory=$False)] 
-	[Switch]$UseSSL=$False
+	[string]$To="",
+
+	[parameter(Mandatory=$False)] 
+	[Switch]$UseSSL=$False 
 
 	)
 	
@@ -914,6 +917,18 @@ Param(
 #
 #Version 2.0 is based on version 1.20
 #
+#Version 3.02 9-Jan-2021
+#	Added to the Computer Hardware section, the server's Power Plan
+#	Changed all Write-Verbose statements from Get-Date to Get-Date -Format G as requested by Guy Leech
+#	Clean up some spacing in the HTML output
+#	Fixed issue with the Services and OU tables where highlighted cells were not in red
+#	Fixed issue with the Word/PDF Domain Admins table with the missing Domain column
+#	In Function OutputTimeServerRegistryKeys, change the call to w32tm to use Invoke-Command to get around access denied errors
+#	Reordered parameters in an order recommended by Guy Leech
+#	Updated Exchange schema versions to include up to Exchange 2016 CU19 and Exchange 2019 CU8
+#	Updated help text
+#	Updated ReadMe file
+#	
 #Version 3.01 12-Oct-2020
 #	Handle the Domain Admins privileged group processing and output the same way the Enterprise and Schema Admins are done
 #
@@ -1039,19 +1054,19 @@ If($MSWord -eq $False -and $PDF -eq $False -and $Text -eq $False -and $HTML -eq 
 
 If($MSWord)
 {
-	Write-Verbose "$(Get-Date): MSWord is set"
+	Write-Verbose "$(Get-Date -Format G): MSWord is set"
 }
 If($PDF)
 {
-	Write-Verbose "$(Get-Date): PDF is set"
+	Write-Verbose "$(Get-Date -Format G): PDF is set"
 }
 If($Text)
 {
-	Write-Verbose "$(Get-Date): Text is set"
+	Write-Verbose "$(Get-Date -Format G): Text is set"
 }
 If($HTML)
 {
-	Write-Verbose "$(Get-Date): HTML is set"
+	Write-Verbose "$(Get-Date -Format G): HTML is set"
 }
 
 If($ADForest -ne "" -and $ADDomain -ne "")
@@ -1073,7 +1088,7 @@ If($MaxDetails)
 
 If($Folder -ne "")
 {
-	Write-Verbose "$(Get-Date): Testing folder path"
+	Write-Verbose "$(Get-Date -Format G): Testing folder path"
 	#does it exist
 	If(Test-Path $Folder -EA 0)
 	{
@@ -1081,7 +1096,7 @@ If($Folder -ne "")
 		If(Test-Path $Folder -pathType Container -EA 0)
 		{
 			#it exists and it is a folder
-			Write-Verbose "$(Get-Date): Folder path $Folder exists and is a folder"
+			Write-Verbose "$(Get-Date -Format G): Folder path $Folder exists and is a folder"
 		}
 		Else
 		{
@@ -1133,12 +1148,12 @@ If($Log)
 	try 
 	{
 		Start-Transcript -Path $Script:LogPath -Force -Verbose:$false | Out-Null
-		Write-Verbose "$(Get-Date): Transcript/log started at $Script:LogPath"
+		Write-Verbose "$(Get-Date -Format G): Transcript/log started at $Script:LogPath"
 		$Script:StartLog = $true
 	} 
 	catch 
 	{
-		Write-Verbose "$(Get-Date): Transcript/log failed at $Script:LogPath"
+		Write-Verbose "$(Get-Date -Format G): Transcript/log failed at $Script:LogPath"
 		$Script:StartLog = $false
 	}
 }
@@ -1235,7 +1250,7 @@ If($MSWord -or $PDF)
 {
 	#try and fix the issue with the $CompanyName variable
 	$Script:CoName = $CompanyName
-	Write-Verbose "$(Get-Date): CoName is $($Script:CoName)"
+	Write-Verbose "$(Get-Date -Format G): CoName is $($Script:CoName)"
 	
 	#the following values were attained from 
 	#http://msdn.microsoft.com/en-us/library/office/aa211923(v=office.11).aspx
@@ -1369,7 +1384,7 @@ If($HTML)
 Function SendEmail
 {
 	Param([array]$Attachments)
-	Write-Verbose "$(Get-Date): Prepare to email"
+	Write-Verbose "$(Get-Date -Format G): Prepare to email"
 
 	$emailAttachment = $Attachments
 	$emailSubject = $Script:Title
@@ -1409,13 +1424,13 @@ $Script:Title is attached.
 		
 		If($?)
 		{
-			Write-Verbose "$(Get-Date): Email successfully sent using anonymous credentials"
+			Write-Verbose "$(Get-Date -Format G): Email successfully sent using anonymous credentials"
 		}
 		ElseIf(!$?)
 		{
 			$e = $error[0]
 
-			Write-Verbose "$(Get-Date): Email was not sent:"
+			Write-Verbose "$(Get-Date -Format G): Email was not sent:"
 			Write-Warning "$(Get-Date): Exception: $e.Exception" 
 		}
 	}
@@ -1423,7 +1438,7 @@ $Script:Title is attached.
 	{
 		If($UseSSL)
 		{
-			Write-Verbose "$(Get-Date): Trying to send email using current user's credentials with SSL"
+			Write-Verbose "$(Get-Date -Format G): Trying to send email using current user's credentials with SSL"
 			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
 			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
 			-UseSSL *>$Null
@@ -1443,7 +1458,7 @@ $Script:Title is attached.
 			If($null -ne $e.Exception -and $e.Exception.ToString().Contains("5.7"))
 			{
 				#The server response was: 5.7.xx SMTP; Client was not authenticated to send anonymous mail during MAIL FROM
-				Write-Verbose "$(Get-Date): Current user's credentials failed. Ask for usable credentials."
+				Write-Verbose "$(Get-Date -Format G): Current user's credentials failed. Ask for usable credentials."
 
 				If($Dev)
 				{
@@ -1469,19 +1484,19 @@ $Script:Title is attached.
 
 				If($?)
 				{
-					Write-Verbose "$(Get-Date): Email successfully sent using new credentials"
+					Write-Verbose "$(Get-Date -Format G): Email successfully sent using new credentials"
 				}
 				ElseIf(!$?)
 				{
 					$e = $error[0]
 
-					Write-Verbose "$(Get-Date): Email was not sent:"
+					Write-Verbose "$(Get-Date -Format G): Email was not sent:"
 					Write-Warning "$(Get-Date): Exception: $e.Exception" 
 				}
 			}
 			Else
 			{
-				Write-Verbose "$(Get-Date): Email was not sent:"
+				Write-Verbose "$(Get-Date -Format G): Email was not sent:"
 				Write-Warning "$(Get-Date): Exception: $e.Exception" 
 			}
 		}
@@ -1504,8 +1519,8 @@ Function GetComputerWMIInfo
 	# modified 29-Apr-2018 to change from Arrays to New-Object System.Collections.ArrayList
 
 	#Get Computer info
-	Write-Verbose "$(Get-Date): `t`tProcessing WMI Computer information"
-	Write-Verbose "$(Get-Date): `t`t`tHardware information"
+	Write-Verbose "$(Get-Date -Format G): `t`tProcessing WMI Computer information"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tHardware information"
 	If($MSWord -or $PDF)
 	{
 		WriteWordLine 3 0 "Computer Information: $($RemoteComputerName)"
@@ -1542,12 +1557,12 @@ Function GetComputerWMIInfo
 
 		ForEach($Item in $ComputerItems)
 		{
-			OutputComputerItem $Item $ComputerOS
+			OutputComputerItem $Item $ComputerOS $RemoteComputerName
 		}
 	}
 	ElseIf(!$?)
 	{
-		Write-Verbose "$(Get-Date): Get-WmiObject win32_computersystem failed for $($RemoteComputerName)"
+		Write-Verbose "$(Get-Date -Format G): Get-WmiObject win32_computersystem failed for $($RemoteComputerName)"
 		Write-Warning "Get-WmiObject win32_computersystem failed for $($RemoteComputerName)"
 		If($MSWORD -or $PDF)
 		{
@@ -1574,7 +1589,7 @@ Function GetComputerWMIInfo
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): No results Returned for Computer information"
+		Write-Verbose "$(Get-Date -Format G): No results Returned for Computer information"
 		If($MSWORD -or $PDF)
 		{
 			WriteWordLine 0 2 "No results Returned for Computer information" "" $Null 0 $False $True
@@ -1590,7 +1605,7 @@ Function GetComputerWMIInfo
 	}
 	
 	#Get Disk info
-	Write-Verbose "$(Get-Date): `t`t`tDrive information"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tDrive information"
 
 	If($MSWord -or $PDF)
 	{
@@ -1631,7 +1646,7 @@ Function GetComputerWMIInfo
 	}
 	ElseIf(!$?)
 	{
-		Write-Verbose "$(Get-Date): Get-WmiObject Win32_LogicalDisk failed for $($RemoteComputerName)"
+		Write-Verbose "$(Get-Date -Format G): Get-WmiObject Win32_LogicalDisk failed for $($RemoteComputerName)"
 		Write-Warning "Get-WmiObject Win32_LogicalDisk failed for $($RemoteComputerName)"
 		If($MSWORD -or $PDF)
 		{
@@ -1657,7 +1672,7 @@ Function GetComputerWMIInfo
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): No results Returned for Drive information"
+		Write-Verbose "$(Get-Date -Format G): No results Returned for Drive information"
 		If($MSWORD -or $PDF)
 		{
 			WriteWordLine 0 2 "No results Returned for Drive information" "" $Null 0 $False $True
@@ -1673,7 +1688,7 @@ Function GetComputerWMIInfo
 	}
 	
 	#Get CPU's and stepping
-	Write-Verbose "$(Get-Date): `t`t`tProcessor information"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tProcessor information"
 
 	If($MSWord -or $PDF)
 	{
@@ -1710,7 +1725,7 @@ Function GetComputerWMIInfo
 	}
 	ElseIf(!$?)
 	{
-		Write-Verbose "$(Get-Date): Get-WmiObject win32_Processor failed for $($RemoteComputerName)"
+		Write-Verbose "$(Get-Date -Format G): Get-WmiObject win32_Processor failed for $($RemoteComputerName)"
 		Write-Warning "Get-WmiObject win32_Processor failed for $($RemoteComputerName)"
 		If($MSWORD -or $PDF)
 		{
@@ -1736,7 +1751,7 @@ Function GetComputerWMIInfo
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): No results Returned for Processor information"
+		Write-Verbose "$(Get-Date -Format G): No results Returned for Processor information"
 		If($MSWORD -or $PDF)
 		{
 			WriteWordLine 0 2 "No results Returned for Processor information" "" $Null 0 $False $True
@@ -1752,7 +1767,7 @@ Function GetComputerWMIInfo
 	}
 
 	#Get Nics
-	Write-Verbose "$(Get-Date): `t`t`tNIC information"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tNIC information"
 
 	If($MSWord -or $PDF)
 	{
@@ -1814,7 +1829,7 @@ Function GetComputerWMIInfo
 				ElseIf(!$?)
 				{
 					Write-Warning "$(Get-Date): Error retrieving NIC information"
-					Write-Verbose "$(Get-Date): Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)"
+					Write-Verbose "$(Get-Date -Format G): Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)"
 					Write-Warning "Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)"
 					If($MSWORD -or $PDF)
 					{
@@ -1843,7 +1858,7 @@ Function GetComputerWMIInfo
 				}
 				Else
 				{
-					Write-Verbose "$(Get-Date): No results Returned for NIC information"
+					Write-Verbose "$(Get-Date -Format G): No results Returned for NIC information"
 					If($MSWORD -or $PDF)
 					{
 						WriteWordLine 0 2 "No results Returned for NIC information" "" $Null 0 $False $True
@@ -1863,7 +1878,7 @@ Function GetComputerWMIInfo
 	ElseIf(!$?)
 	{
 		Write-Warning "$(Get-Date): Error retrieving NIC configuration information"
-		Write-Verbose "$(Get-Date): Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)"
+		Write-Verbose "$(Get-Date -Format G): Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)"
 		Write-Warning "Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)"
 		If($MSWORD -or $PDF)
 		{
@@ -1892,7 +1907,7 @@ Function GetComputerWMIInfo
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): No results Returned for NIC configuration information"
+		Write-Verbose "$(Get-Date -Format G): No results Returned for NIC configuration information"
 		If($MSWORD -or $PDF)
 		{
 			WriteWordLine 0 2 "No results Returned for NIC configuration information" "" $Null 0 $False $True
@@ -1923,7 +1938,25 @@ Function GetComputerWMIInfo
 
 Function OutputComputerItem
 {
-	Param([object]$Item, [string]$OS)
+	Param([object]$Item, [string]$OS, [string]$RemoteComputerName)
+	
+	#get computer's power plan
+	#https://techcommunity.microsoft.com/t5/core-infrastructure-and-security/get-the-active-power-plan-of-multiple-servers-with-powershell/ba-p/370429
+	
+	try 
+	{
+
+		$PowerPlan = (Get-WmiObject -ComputerName $RemoteComputerName -Class Win32_PowerPlan -Namespace "root\cimv2\power" |
+			Where-Object {$_.IsActive -eq $true} |
+			Select-Object @{Name = "PowerPlan"; Expression = {$_.ElementName}}).PowerPlan
+	}
+
+	catch 
+	{
+
+		$PowerPlan = $_.Exception
+
+	}	
 	
 	If($MSWord -or $PDF)
 	{
@@ -1932,6 +1965,7 @@ Function OutputComputerItem
 		$ItemInformation.Add(@{ Data = "Model"; Value = $Item.model; }) > $Null
 		$ItemInformation.Add(@{ Data = "Domain"; Value = $Item.domain; }) > $Null
 		$ItemInformation.Add(@{ Data = "Operating System"; Value = $OS; }) > $Null
+		$ItemInformation.Add(@{ Data = "Power Plan"; Value = $PowerPlan; }) > $Null
 		$ItemInformation.Add(@{ Data = "Total Ram"; Value = "$($Item.totalphysicalram) GB"; }) > $Null
 		$ItemInformation.Add(@{ Data = "Physical Processors (sockets)"; Value = $Item.NumberOfProcessors; }) > $Null
 		$ItemInformation.Add(@{ Data = "Logical Processors (cores w/HT)"; Value = $Item.NumberOfLogicalProcessors; }) > $Null
@@ -1960,6 +1994,7 @@ Function OutputComputerItem
 		Line 2 "Model`t`t`t`t: " $Item.model
 		Line 2 "Domain`t`t`t`t: " $Item.domain
 		Line 2 "Operating System`t`t: " $OS
+		Line 2 "Power Plan`t`t`t: " $PowerPlan
 		Line 2 "Total Ram`t`t`t: $($Item.totalphysicalram) GB"
 		Line 2 "Physical Processors (sockets)`t: " $Item.NumberOfProcessors
 		Line 2 "Logical Processors (cores w/HT)`t: " $Item.NumberOfLogicalProcessors
@@ -1971,6 +2006,8 @@ Function OutputComputerItem
 		$columnHeaders = @("Manufacturer",($htmlsilver -bor $htmlBold),$Item.manufacturer,$htmlwhite)
 		$rowdata += @(,('Model',($htmlsilver -bor $htmlBold),$Item.model,$htmlwhite))
 		$rowdata += @(,('Domain',($htmlsilver -bor $htmlBold),$Item.domain,$htmlwhite))
+		$rowdata += @(,('Operating System',($htmlsilver -bor $htmlBold),$OS,$htmlwhite))
+		$rowdata += @(,('Power Plan',($htmlsilver -bor $htmlBold),$PowerPlan,$htmlwhite))
 		$rowdata += @(,('Total Ram',($htmlsilver -bor $htmlBold),"$($Item.totalphysicalram) GB",$htmlwhite))
 		$rowdata += @(,('Physical Processors (sockets)',($htmlsilver -bor $htmlBold),$Item.NumberOfProcessors,$htmlwhite))
 		$rowdata += @(,('Logical Processors (cores w/HT)',($htmlsilver -bor $htmlBold),$Item.NumberOfLogicalProcessors,$htmlwhite))
@@ -1978,7 +2015,7 @@ Function OutputComputerItem
 		$msg = ""
 		$columnWidths = @("150px","200px")
 		FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths -tablewidth "350"
-		WriteHTMLLine 0 0 " "
+		#WriteHTMLLine 0 0 " "
 	}
 }
 
@@ -2108,7 +2145,7 @@ Function OutputDriveItem
 		$msg = ""
 		$columnWidths = @("150px","200px")
 		FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths -tablewidth "350"
-		WriteHTMLLine 0 0 " "
+		#WriteHTMLLine 0 0 " "
 	}
 }
 
@@ -2233,7 +2270,7 @@ Function OutputProcessorItem
 		$msg = ""
 		$columnWidths = @("150px","200px")
 		FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths -tablewidth "350"
-		WriteHTMLLine 0 0 " "
+		#WriteHTMLLine 0 0 " "
 	}
 }
 
@@ -2682,7 +2719,7 @@ Function OutputNicItem
 		$msg = ""
 		$columnWidths = @("150px","200px")
 		FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths -tablewidth "350"
-		WriteHTMLLine 0 0 " "
+		#WriteHTMLLine 0 0 " "
 	}
 }
 #endregion
@@ -2694,7 +2731,7 @@ Function GetComputerServices
 	# modified 29-Apr-2018 to change from Arrays to New-Object System.Collections.ArrayList
 	
 	#Get Computer services info
-	Write-Verbose "$(Get-Date): `t`tProcessing Computer services information"
+	Write-Verbose "$(Get-Date -Format G): `t`tProcessing Computer services information"
 	If($MSWORD -or $PDF)
 	{
 		WriteWordLine 3 0 "Services"
@@ -2726,17 +2763,15 @@ Function GetComputerServices
 	If($? -and $Null -ne $Services)
 	{
 		[int]$NumServices = $Services.count
-		Write-Verbose "$(Get-Date): `t`t$($NumServices) Services found"
+		Write-Verbose "$(Get-Date -Format G): `t`t$($NumServices) Services found"
 
 		If($MSWord -or $PDF)
 		{
 			WriteWordLine 0 1 "Services ($NumServices Services found)"
 
 			$ServicesWordTable = New-Object System.Collections.ArrayList
-			## Create an array of hashtables to store references of cells that we wish to highlight after the table has been added
-			$HighlightedCells = New-Object System.Collections.ArrayList
-			## Seed the $Services row index from the second row
-			[int] $CurrentServiceIndex = 2;
+			$WordHighlightedCells = New-Object System.Collections.ArrayList
+			[int] $CurrentServiceIndex = 2
 		}
 		If($Text)
 		{
@@ -2782,7 +2817,7 @@ Function GetComputerServices
 				## Store "to highlight" cell references
 				If($Service.State -like "Stopped" -and $Service.StartMode -like "Auto") 
 				{
-					$HighlightedCells.Add(@{ Row = $CurrentServiceIndex; Column = 2; }) > $Null
+					$WordHighlightedCells.Add(@{ Row = $CurrentServiceIndex; Column = 2; }) > $Null
 				}
 				$CurrentServiceIndex++;
 			}
@@ -2805,14 +2840,14 @@ Function GetComputerServices
 			{
 				If($Service.State -like "Stopped" -and $Service.StartMode -like "Auto") 
 				{
-					$HighlightedCells = $htmlred
+					$HTMLHighlightedCells = $htmlred
 				}
 				Else
 				{
-					$HighlightedCells = $htmlwhite
+					$HTMLHighlightedCells = $htmlwhite
 				} 
 				$rowdata[ $rowIndx ] = @(,($Service.DisplayName,$htmlwhite,
-								$Service.State,$HighlightedCells,
+								$Service.State,$HTMLHighlightedCells,
 								$Service.StartMode,$htmlwhite))
 				$rowIndx++
 			}
@@ -2820,17 +2855,14 @@ Function GetComputerServices
 
 		If($MSWord -or $PDF)
 		{
-			## Add the table to the document, using the hashtable
 			$Table = AddWordTable -Hashtable $ServicesWordTable `
 			-Columns DisplayName, Status, StartMode `
 			-Headers "Display Name", "Status", "Startup Type" `
 			-Format $wdTableGrid `
 			-AutoFit $wdAutoFitContent;
 
-			## IB - Set the header row format after the SetWordTableAlternateRowColor Function as it will paint the header row!
 			SetWordCellFormat -Collection $Table.Rows.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
-			## IB - Set the required highlighted cells
-			SetWordCellFormat -Coordinates $HighlightedCells -Table $Table -Bold -BackgroundColor $wdColorRed -Solid;
+			SetWordCellFormat -Coordinates $WordHighlightedCells -Table $Table -Bold -BackgroundColor $wdColorRed -Solid;
 
 			$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
 
@@ -2940,7 +2972,7 @@ Function BuildDCDNSIPConfigTable
 				
 				If($? -and $Null -ne $ThisNic)
 				{
-					Write-Verbose "$(Get-Date): `t`t`tGather DC DNS IP Config info"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tGather DC DNS IP Config info"
 					$xIPAddress = @()
 					ForEach($IPAddress in $Nic.ipaddress)
 					{
@@ -3010,7 +3042,7 @@ Function BuildDCDNSIPConfigTable
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): No results Returned for NIC configuration information"
+		Write-Verbose "$(Get-Date -Format G): No results Returned for NIC configuration information"
 		If($MSWORD -or $PDF)
 		{
 			WriteWordLine 0 2 "No results Returned for NIC configuration information" "" $Null 0 $False $True
@@ -3508,7 +3540,7 @@ Function FindWordDocumentEnd
 
 Function SetupWord
 {
-	Write-Verbose "$(Get-Date): Setting up Word"
+	Write-Verbose "$(Get-Date -Format G): Setting up Word"
     
 	If(!$AddDateTime)
 	{
@@ -3528,7 +3560,7 @@ Function SetupWord
 	}
 
 	# Setup word for output
-	Write-Verbose "$(Get-Date): Create Word comObject."
+	Write-Verbose "$(Get-Date -Format G): Create Word comObject."
 	$Script:Word = New-Object -comobject "Word.Application" -EA 0 4>$Null
 	
 	If(!$? -or $Null -eq $Script:Word)
@@ -3546,7 +3578,7 @@ Function SetupWord
 		Exit
 	}
 
-	Write-Verbose "$(Get-Date): Determine Word language value"
+	Write-Verbose "$(Get-Date -Format G): Determine Word language value"
 	If( ( validStateProp $Script:Word Language Value__ ) )
 	{
 		[int]$Script:WordLanguageValue = [int]$Script:Word.Language.Value__
@@ -3570,7 +3602,7 @@ Function SetupWord
 		"
 		AbortScript
 	}
-	Write-Verbose "$(Get-Date): Word language value is $($Script:WordLanguageValue)"
+	Write-Verbose "$(Get-Date -Format G): Word language value is $($Script:WordLanguageValue)"
 	
 	$Script:WordCultureCode = GetCulture $Script:WordLanguageValue
 	
@@ -3630,7 +3662,7 @@ Function SetupWord
 	#only validate CompanyName if the field is blank
 	If([String]::IsNullOrEmpty($CompanyName))
 	{
-		Write-Verbose "$(Get-Date): Company name is blank. Retrieve company name from registry."
+		Write-Verbose "$(Get-Date -Format G): Company name is blank. Retrieve company name from registry."
 		$TmpName = ValidateCompanyName
 		
 		If([String]::IsNullOrEmpty($TmpName))
@@ -3645,7 +3677,7 @@ Function SetupWord
 		Else
 		{
 			$Script:CoName = $TmpName
-			Write-Verbose "$(Get-Date): Updated company name to $($Script:CoName)"
+			Write-Verbose "$(Get-Date -Format G): Updated company name to $($Script:CoName)"
 		}
 	}
 	Else
@@ -3655,7 +3687,7 @@ Function SetupWord
 
 	If($Script:WordCultureCode -ne "en-")
 	{
-		Write-Verbose "$(Get-Date): Check Default Cover Page for $($WordCultureCode)"
+		Write-Verbose "$(Get-Date -Format G): Check Default Cover Page for $($WordCultureCode)"
 		[bool]$CPChanged = $False
 		Switch ($Script:WordCultureCode)
 		{
@@ -3758,11 +3790,11 @@ Function SetupWord
 
 		If($CPChanged)
 		{
-			Write-Verbose "$(Get-Date): Changed Default Cover Page from Sideline to $($CoverPage)"
+			Write-Verbose "$(Get-Date -Format G): Changed Default Cover Page from Sideline to $($CoverPage)"
 		}
 	}
 
-	Write-Verbose "$(Get-Date): Validate cover page $($CoverPage) for culture code $($Script:WordCultureCode)"
+	Write-Verbose "$(Get-Date -Format G): Validate cover page $($CoverPage) for culture code $($Script:WordCultureCode)"
 	[bool]$ValidCP = $False
 	
 	$ValidCP = ValidateCoverPage $Script:WordVersion $CoverPage $Script:WordCultureCode
@@ -3770,8 +3802,8 @@ Function SetupWord
 	If(!$ValidCP)
 	{
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Verbose "$(Get-Date): Word language value $($Script:WordLanguageValue)"
-		Write-Verbose "$(Get-Date): Culture code $($Script:WordCultureCode)"
+		Write-Verbose "$(Get-Date -Format G): Word language value $($Script:WordLanguageValue)"
+		Write-Verbose "$(Get-Date -Format G): Culture code $($Script:WordCultureCode)"
 		Write-Error "
 		`n`n
 		`t`t
@@ -3788,7 +3820,7 @@ Function SetupWord
 
 	#http://jdhitsolutions.com/blog/2012/05/san-diego-2012-powershell-deep-dive-slides-and-demos/
 	#using Jeff's Demo-WordReport.ps1 file for examples
-	Write-Verbose "$(Get-Date): Load Word Templates"
+	Write-Verbose "$(Get-Date -Format G): Load Word Templates"
 
 	[bool]$Script:CoverPagesExist = $False
 	[bool]$BuildingBlocksExist = $False
@@ -3797,7 +3829,7 @@ Function SetupWord
 	#word 2010/2013/2016
 	$BuildingBlocksCollection = $Script:Word.Templates | Where-Object{$_.name -eq "Built-In Building Blocks.dotx"}
 
-	Write-Verbose "$(Get-Date): Attempt to load cover page $($CoverPage)"
+	Write-Verbose "$(Get-Date -Format G): Attempt to load cover page $($CoverPage)"
 	$part = $Null
 
 	$BuildingBlocksCollection | 
@@ -3830,16 +3862,16 @@ Function SetupWord
 
 	If(!$Script:CoverPagesExist)
 	{
-		Write-Verbose "$(Get-Date): Cover Pages are not installed or the Cover Page $($CoverPage) does not exist."
+		Write-Verbose "$(Get-Date -Format G): Cover Pages are not installed or the Cover Page $($CoverPage) does not exist."
 		Write-Host "Cover Pages are not installed or the Cover Page $($CoverPage) does not exist." -Foreground White
 		Write-Host "This report will not have a Cover Page." -Foreground White
 	}
 
-	Write-Verbose "$(Get-Date): Create empty word doc"
+	Write-Verbose "$(Get-Date -Format G): Create empty word doc"
 	$Script:Doc = $Script:Word.Documents.Add()
 	If($Null -eq $Script:Doc)
 	{
-		Write-Verbose "$(Get-Date): "
+		Write-Verbose "$(Get-Date -Format G): "
 		$ErrorActionPreference = $SaveEAPreference
 		Write-Error "
 		`n`n
@@ -3853,7 +3885,7 @@ Function SetupWord
 	$Script:Selection = $Script:Word.Selection
 	If($Null -eq $Script:Selection)
 	{
-		Write-Verbose "$(Get-Date): "
+		Write-Verbose "$(Get-Date -Format G): "
 		$ErrorActionPreference = $SaveEAPreference
 		Write-Error "
 		`n`n
@@ -3869,7 +3901,7 @@ Function SetupWord
 	$Script:Word.ActiveDocument.DefaultTabStop = 36
 
 	#Disable Spell and Grammar Check to resolve issue and improve performance (from Pat Coughlin)
-	Write-Verbose "$(Get-Date): Disable grammar and spell checking"
+	Write-Verbose "$(Get-Date -Format G): Disable grammar and spell checking"
 	#bug reported 1-Apr-2014 by Tim Mangan
 	#save current options first before turning them off
 	$Script:CurrentGrammarOption = $Script:Word.Options.CheckGrammarAsYouType
@@ -3880,16 +3912,16 @@ Function SetupWord
 	If($BuildingBlocksExist)
 	{
 		#insert new page, getting ready for table of contents
-		Write-Verbose "$(Get-Date): Insert new page, getting ready for table of contents"
+		Write-Verbose "$(Get-Date -Format G): Insert new page, getting ready for table of contents"
 		$part.Insert($Script:Selection.Range,$True) | Out-Null
 		$Script:Selection.InsertNewPage()
 
 		#table of contents
-		Write-Verbose "$(Get-Date): Table of Contents - $($Script:MyHash.Word_TableOfContents)"
+		Write-Verbose "$(Get-Date -Format G): Table of Contents - $($Script:MyHash.Word_TableOfContents)"
 		$toc = $BuildingBlocks.BuildingBlockEntries.Item($Script:MyHash.Word_TableOfContents)
 		If($Null -eq $toc)
 		{
-			Write-Verbose "$(Get-Date): "
+			Write-Verbose "$(Get-Date -Format G): "
 			Write-Host "Table of Content - $($Script:MyHash.Word_TableOfContents) could not be retrieved." -Foreground White
 			Write-Host "This report will not have a Table of Contents." -Foreground White
 		}
@@ -3905,11 +3937,11 @@ Function SetupWord
 	}
 
 	#set the footer
-	Write-Verbose "$(Get-Date): Set the footer"
+	Write-Verbose "$(Get-Date -Format G): Set the footer"
 	[string]$footertext = "Report created by $username"
 
 	#get the footer
-	Write-Verbose "$(Get-Date): Get the footer and format font"
+	Write-Verbose "$(Get-Date -Format G): Get the footer and format font"
 	$Script:Doc.ActiveWindow.ActivePane.view.SeekView = $wdSeekPrimaryFooter
 	#get the footer and format font
 	$footers = $Script:Doc.Sections.Last.Footers
@@ -3923,15 +3955,15 @@ Function SetupWord
 			$footer.range.Font.Bold = $True
 		}
 	} #end ForEach
-	Write-Verbose "$(Get-Date): Footer text"
+	Write-Verbose "$(Get-Date -Format G): Footer text"
 	$Script:Selection.HeaderFooter.Range.Text = $footerText
 
 	#add page numbering
-	Write-Verbose "$(Get-Date): Add page numbering"
+	Write-Verbose "$(Get-Date -Format G): Add page numbering"
 	$Script:Selection.HeaderFooter.PageNumbers.Add($wdAlignPageNumberRight) | Out-Null
 
 	FindWordDocumentEnd
-	Write-Verbose "$(Get-Date):"
+	Write-Verbose "$(Get-Date -Format G):"
 	#end of Jeff Hicks 
 }
 
@@ -3940,7 +3972,7 @@ Function UpdateDocumentProperties
 	Param([string]$AbstractTitle, [string]$SubjectTitle)
 	#updated 8-Jun-2017 with additional cover page fields
 	#Update document properties
-	Write-Verbose "$(Get-Date): Set Cover Page Properties"
+	Write-Verbose "$(Get-Date -Format G): Set Cover Page Properties"
 	#8-Jun-2017 put these 4 items in alpha order
 	Set-DocumentProperty -Document $Script:Doc -DocProperty Author -Value $UserName
 	Set-DocumentProperty -Document $Script:Doc -DocProperty Company -Value $Script:CoName
@@ -3992,7 +4024,7 @@ Function UpdateDocumentProperties
 	[string]$abstract = (Get-Date -Format d).ToString()
 	$ab.Text = $abstract
 
-	Write-Verbose "$(Get-Date): Update the Table of Contents"
+	Write-Verbose "$(Get-Date -Format G): Update the Table of Contents"
 	#update the Table of Contents
 	$Script:Doc.TablesOfContents.item(1).Update()
 	$cp = $Null
@@ -5080,7 +5112,7 @@ Function CheckHTMLColor
 
 Function SetupHTML
 {
-	Write-Verbose "$(Get-Date): Setting up HTML"
+	Write-Verbose "$(Get-Date -Format G): Setting up HTML"
 	If(!$AddDateTime)
 	{
 		[string]$Script:HTMLFileName = "$($Script:pwdpath)\$($OutputFileName).html"
@@ -5632,7 +5664,7 @@ Function AbortScript
 	If($MSWord -or $PDF)
 	{
 		$Script:Word.quit()
-		Write-Verbose "$(Get-Date): System Cleanup"
+		Write-Verbose "$(Get-Date -Format G): System Cleanup"
 		[System.Runtime.Interopservices.Marshal]::ReleaseComObject($Script:Word) | Out-Null
 		If(Test-Path variable:global:word)
 		{
@@ -5641,7 +5673,7 @@ Function AbortScript
 	}
 	[gc]::collect() 
 	[gc]::WaitForPendingFinalizers()
-	Write-Verbose "$(Get-Date): Script has been aborted"
+	Write-Verbose "$(Get-Date -Format G): Script has been aborted"
 	$ErrorActionPreference = $SaveEAPreference
 	Exit
 }
@@ -5729,7 +5761,7 @@ Function UserIsaDomainAdmin
 	#Function adapted from sample code provided by Thomas Vuylsteke
 	$IsDA = $False
 	$name = $env:username
-	Write-Verbose "$(Get-Date): TokenGroups - Checking groups for $name"
+	Write-Verbose "$(Get-Date -Format G): TokenGroups - Checking groups for $name"
 
 	$root = [ADSI]""
 	$filter = "(sAMAccountName=$name)"
@@ -5762,7 +5794,7 @@ Function ElevatedSession
 
 	If($currentPrincipal.IsInRole( [Security.Principal.WindowsBuiltInRole]::Administrator ))
 	{
-		Write-Verbose "$(Get-Date): This is an elevated PowerShell session"
+		Write-Verbose "$(Get-Date -Format G): This is an elevated PowerShell session"
 		Return $True
 	}
 	Else
@@ -5903,7 +5935,7 @@ Function Get-ComputerCountByOS
 
 	$ADSearchBase = $DomainDistinguishedName
 
-	Write-Verbose "$(Get-Date): `t`tGathering computer misc data"
+	Write-Verbose "$(Get-Date -Format G): `t`tGathering computer misc data"
 
 	# Create an LDAP search for all computer objects
 	$ADFilter = '(objectCategory=computer)'
@@ -6534,84 +6566,84 @@ Function Get-ComputerCountByOS
 
 Function ShowScriptOptions
 {
-	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): AddDateTime     : $AddDateTime"
+	Write-Verbose "$(Get-Date -Format G): "
+	Write-Verbose "$(Get-Date -Format G): "
+	Write-Verbose "$(Get-Date -Format G): AddDateTime     : $AddDateTime"
 	If($MSWORD -or $PDF)
 	{
-		Write-Verbose "$(Get-Date): Company Name    : $Script:CoName"
+		Write-Verbose "$(Get-Date -Format G): Company Name    : $Script:CoName"
 	}
-	Write-Verbose "$(Get-Date): ComputerName    : $ComputerName"
+	Write-Verbose "$(Get-Date -Format G): ComputerName    : $ComputerName"
 	If($MSWORD -or $PDF)
 	{
-		Write-Verbose "$(Get-Date): Company Address : $CompanyAddress"
-		Write-Verbose "$(Get-Date): Company Email   : $CompanyEmail"
-		Write-Verbose "$(Get-Date): Company Fax     : $CompanyFax"
-		Write-Verbose "$(Get-Date): Company Phone   : $CompanyPhone"
-		Write-Verbose "$(Get-Date): Cover Page      : $CoverPage"
+		Write-Verbose "$(Get-Date -Format G): Company Address : $CompanyAddress"
+		Write-Verbose "$(Get-Date -Format G): Company Email   : $CompanyEmail"
+		Write-Verbose "$(Get-Date -Format G): Company Fax     : $CompanyFax"
+		Write-Verbose "$(Get-Date -Format G): Company Phone   : $CompanyPhone"
+		Write-Verbose "$(Get-Date -Format G): Cover Page      : $CoverPage"
 	}
-	Write-Verbose "$(Get-Date): DCDNSInfo       : $DCDNSInfo"
-	Write-Verbose "$(Get-Date): Dev             : $Dev"
+	Write-Verbose "$(Get-Date -Format G): DCDNSInfo       : $DCDNSInfo"
+	Write-Verbose "$(Get-Date -Format G): Dev             : $Dev"
 	If($Dev)
 	{
-		Write-Verbose "$(Get-Date): DevErrorFile    : $Script:DevErrorFile"
+		Write-Verbose "$(Get-Date -Format G): DevErrorFile    : $Script:DevErrorFile"
 	}
-	Write-Verbose "$(Get-Date): Domain Name     : $ADDomain"
-	Write-Verbose "$(Get-Date): Elevated        : $Script:Elevated"
+	Write-Verbose "$(Get-Date -Format G): Domain Name     : $ADDomain"
+	Write-Verbose "$(Get-Date -Format G): Elevated        : $Script:Elevated"
 	If($MSWord)
 	{
-		Write-Verbose "$(Get-Date): Word FileName   : $($Script:WordFileName)"
+		Write-Verbose "$(Get-Date -Format G): Word FileName   : $($Script:WordFileName)"
 	}
 	If($HTML)
 	{
-		Write-Verbose "$(Get-Date): HTML FileName   : $($Script:HTMLFileName)"
+		Write-Verbose "$(Get-Date -Format G): HTML FileName   : $($Script:HTMLFileName)"
 	} 
 	If($PDF)
 	{
-		Write-Verbose "$(Get-Date): PDF FileName    : $($Script:PDFFileName)"
+		Write-Verbose "$(Get-Date -Format G): PDF FileName    : $($Script:PDFFileName)"
 	}
 	If($Text)
 	{
-		Write-Verbose "$(Get-Date): Text FileName   : $($Script:TextFileName)"
+		Write-Verbose "$(Get-Date -Format G): Text FileName   : $($Script:TextFileName)"
 	}
-	Write-Verbose "$(Get-Date): Folder          : $Folder"
-	Write-Verbose "$(Get-Date): Forest Name     : $ADForest"
-	Write-Verbose "$(Get-Date): From            : $From"
-	Write-Verbose "$(Get-Date): GPOInheritance  : $GPOInheritance"
-	Write-Verbose "$(Get-Date): HW Inventory    : $Hardware"
-	Write-Verbose "$(Get-Date): IncludeUserInfo : $IncludeUserInfo"
-	Write-Verbose "$(Get-Date): Log             : $($Log)"
-	Write-Verbose "$(Get-Date): MaxDetail       : $MaxDetails"
-	Write-Verbose "$(Get-Date): Save As HTML    : $HTML"
-	Write-Verbose "$(Get-Date): Save As PDF     : $PDF"
-	Write-Verbose "$(Get-Date): Save As TEXT    : $TEXT"
-	Write-Verbose "$(Get-Date): Save As WORD    : $MSWORD"
-	Write-Verbose "$(Get-Date): ScriptInfo      : $ScriptInfo"
-	Write-Verbose "$(Get-Date): Section         : $Section"
-	Write-Verbose "$(Get-Date): Services        : $Services"
-	Write-Verbose "$(Get-Date): Smtp Port       : $SmtpPort"
-	Write-Verbose "$(Get-Date): Smtp Server     : $SmtpServer"
-	Write-Verbose "$(Get-Date): Title           : $Script:Title"
-	Write-Verbose "$(Get-Date): To              : $To"
-	Write-Verbose "$(Get-Date): Use SSL         : $UseSSL"
+	Write-Verbose "$(Get-Date -Format G): Folder          : $Folder"
+	Write-Verbose "$(Get-Date -Format G): Forest Name     : $ADForest"
+	Write-Verbose "$(Get-Date -Format G): From            : $From"
+	Write-Verbose "$(Get-Date -Format G): GPOInheritance  : $GPOInheritance"
+	Write-Verbose "$(Get-Date -Format G): HW Inventory    : $Hardware"
+	Write-Verbose "$(Get-Date -Format G): IncludeUserInfo : $IncludeUserInfo"
+	Write-Verbose "$(Get-Date -Format G): Log             : $($Log)"
+	Write-Verbose "$(Get-Date -Format G): MaxDetail       : $MaxDetails"
+	Write-Verbose "$(Get-Date -Format G): Save As HTML    : $HTML"
+	Write-Verbose "$(Get-Date -Format G): Save As PDF     : $PDF"
+	Write-Verbose "$(Get-Date -Format G): Save As TEXT    : $TEXT"
+	Write-Verbose "$(Get-Date -Format G): Save As WORD    : $MSWORD"
+	Write-Verbose "$(Get-Date -Format G): ScriptInfo      : $ScriptInfo"
+	Write-Verbose "$(Get-Date -Format G): Section         : $Section"
+	Write-Verbose "$(Get-Date -Format G): Services        : $Services"
+	Write-Verbose "$(Get-Date -Format G): Smtp Port       : $SmtpPort"
+	Write-Verbose "$(Get-Date -Format G): Smtp Server     : $SmtpServer"
+	Write-Verbose "$(Get-Date -Format G): Title           : $Script:Title"
+	Write-Verbose "$(Get-Date -Format G): To              : $To"
+	Write-Verbose "$(Get-Date -Format G): Use SSL         : $UseSSL"
 	If($MSWORD -or $PDF)
 	{
-		Write-Verbose "$(Get-Date): User Name       : $UserName"
+		Write-Verbose "$(Get-Date -Format G): User Name       : $UserName"
 	}
-	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): OS Detected     : $Script:RunningOS"
-	Write-Verbose "$(Get-Date): PoSH version    : $($Host.Version)"
-	Write-Verbose "$(Get-Date): PSCulture       : $PSCulture"
-	Write-Verbose "$(Get-Date): PSUICulture     : $PSUICulture"
+	Write-Verbose "$(Get-Date -Format G): "
+	Write-Verbose "$(Get-Date -Format G): OS Detected     : $Script:RunningOS"
+	Write-Verbose "$(Get-Date -Format G): PoSH version    : $($Host.Version)"
+	Write-Verbose "$(Get-Date -Format G): PSCulture       : $PSCulture"
+	Write-Verbose "$(Get-Date -Format G): PSUICulture     : $PSUICulture"
 	If($MSWORD -or $PDF)
 	{
-		Write-Verbose "$(Get-Date): Word language   : $Script:WordLanguageValue"
-		Write-Verbose "$(Get-Date): Word version    : $Script:WordProduct"
+		Write-Verbose "$(Get-Date -Format G): Word language   : $Script:WordLanguageValue"
+		Write-Verbose "$(Get-Date -Format G): Word version    : $Script:WordProduct"
 	}
-	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): Script start    : $Script:StartTime"
-	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): "
+	Write-Verbose "$(Get-Date -Format G): Script start    : $Script:StartTime"
+	Write-Verbose "$(Get-Date -Format G): "
+	Write-Verbose "$(Get-Date -Format G): "
 }
 
 Function SaveandCloseDocumentandShutdownWord
@@ -6621,7 +6653,7 @@ Function SaveandCloseDocumentandShutdownWord
 	$Script:Word.Options.CheckGrammarAsYouType = $Script:CurrentGrammarOption
 	$Script:Word.Options.CheckSpellingAsYouType = $Script:CurrentSpellingOption
 
-	Write-Verbose "$(Get-Date): Save and Close document and Shutdown Word"
+	Write-Verbose "$(Get-Date -Format G): Save and Close document and Shutdown Word"
 	If($Script:WordVersion -eq $wdWord2010)
 	{
 		#the $saveFormat below passes StrictMode 2
@@ -6629,18 +6661,18 @@ Function SaveandCloseDocumentandShutdownWord
 		#http://msdn.microsoft.com/en-us/library/microsoft.office.interop.word.wdsaveformat(v=office.14).aspx
 		If($PDF)
 		{
-			Write-Verbose "$(Get-Date): Saving as DOCX file first before saving to PDF"
+			Write-Verbose "$(Get-Date -Format G): Saving as DOCX file first before saving to PDF"
 		}
 		Else
 		{
-			Write-Verbose "$(Get-Date): Saving DOCX file"
+			Write-Verbose "$(Get-Date -Format G): Saving DOCX file"
 		}
-		Write-Verbose "$(Get-Date): Running $($Script:WordProduct) and detected operating system $($Script:RunningOS)"
+		Write-Verbose "$(Get-Date -Format G): Running $($Script:WordProduct) and detected operating system $($Script:RunningOS)"
 		$saveFormat = [Enum]::Parse([Microsoft.Office.Interop.Word.WdSaveFormat], "wdFormatDocumentDefault")
 		$Script:Doc.SaveAs([REF]$Script:WordFileName, [ref]$SaveFormat)
 		If($PDF)
 		{
-			Write-Verbose "$(Get-Date): Now saving as PDF"
+			Write-Verbose "$(Get-Date -Format G): Now saving as PDF"
 			$saveFormat = [Enum]::Parse([Microsoft.Office.Interop.Word.WdSaveFormat], "wdFormatPDF")
 			$Script:Doc.SaveAs([REF]$Script:PDFFileName, [ref]$saveFormat)
 		}
@@ -6649,25 +6681,25 @@ Function SaveandCloseDocumentandShutdownWord
 	{
 		If($PDF)
 		{
-			Write-Verbose "$(Get-Date): Saving as DOCX file first before saving to PDF"
+			Write-Verbose "$(Get-Date -Format G): Saving as DOCX file first before saving to PDF"
 		}
 		Else
 		{
-			Write-Verbose "$(Get-Date): Saving DOCX file"
+			Write-Verbose "$(Get-Date -Format G): Saving DOCX file"
 		}
-		Write-Verbose "$(Get-Date): Running $($Script:WordProduct) and detected operating system $($Script:RunningOS)"
+		Write-Verbose "$(Get-Date -Format G): Running $($Script:WordProduct) and detected operating system $($Script:RunningOS)"
 		$Script:Doc.SaveAs2([REF]$Script:WordFileName, [ref]$wdFormatDocumentDefault)
 		If($PDF)
 		{
-			Write-Verbose "$(Get-Date): Now saving as PDF"
+			Write-Verbose "$(Get-Date -Format G): Now saving as PDF"
 			$Script:Doc.SaveAs([REF]$Script:PDFFileName, [ref]$wdFormatPDF)
 		}
 	}
 
-	Write-Verbose "$(Get-Date): Closing Word"
+	Write-Verbose "$(Get-Date -Format G): Closing Word"
 	$Script:Doc.Close()
 	$Script:Word.Quit()
-	Write-Verbose "$(Get-Date): System Cleanup"
+	Write-Verbose "$(Get-Date -Format G): System Cleanup"
 	[System.Runtime.Interopservices.Marshal]::ReleaseComObject($Script:Word) | Out-Null
 	If(Test-Path variable:global:word)
 	{
@@ -6687,14 +6719,14 @@ Function SaveandCloseDocumentandShutdownWord
 	$wordprocess = ((Get-Process 'WinWord' -ea 0) | Where-Object {$_.SessionId -eq $SessionID}).Id
 	If($null -ne $wordprocess -and $wordprocess -gt 0)
 	{
-		Write-Verbose "$(Get-Date): WinWord process is still running. Attempting to stop WinWord process # $($wordprocess)"
+		Write-Verbose "$(Get-Date -Format G): WinWord process is still running. Attempting to stop WinWord process # $($wordprocess)"
 		Stop-Process $wordprocess -EA 0
 	}
 }
 
 Function SetupText
 {
-	Write-Verbose "$(Get-Date): Setting up Text"
+	Write-Verbose "$(Get-Date -Format G): Setting up Text"
 
 	[System.Text.StringBuilder] $global:Output = New-Object System.Text.StringBuilder( 16384 )
 
@@ -6710,13 +6742,13 @@ Function SetupText
 
 Function SaveandCloseTextDocument
 {
-	Write-Verbose "$(Get-Date): Saving Text file"
+	Write-Verbose "$(Get-Date -Format G): Saving Text file"
 	Write-Output $global:Output.ToString() | Out-File $Script:TextFileName 4>$Null
 }
 
 Function SaveandCloseHTMLDocument
 {
-	Write-Verbose "$(Get-Date): Saving HTML file"
+	Write-Verbose "$(Get-Date -Format G): Saving HTML file"
 	Out-File -FilePath $Script:HTMLFileName -Append -InputObject "<p></p></body></html>" 4>$Null
 }
 
@@ -6748,7 +6780,7 @@ Function SetFilenames
 Function ProcessScriptSetup
 {
 	#If hardware inventory or services are requested, make sure user is running the script with Domain Admin rights
-	Write-Verbose "$(Get-Date): `tTesting to see if $env:username has Domain Admin rights"
+	Write-Verbose "$(Get-Date -Format G): `tTesting to see if $env:username has Domain Admin rights"
 	
 	$AmIReallyDA = UserIsaDomainAdmin
 	If($AmIReallyDA -eq $True)
@@ -6756,24 +6788,24 @@ Function ProcessScriptSetup
 		#user has Domain Admin rights
 		If($ADDomain -ne "")
 		{
-			Write-Verbose "$(Get-Date): $env:username has Domain Admin rights in the $ADDomain Domain"
+			Write-Verbose "$(Get-Date -Format G): $env:username has Domain Admin rights in the $ADDomain Domain"
 		}
 		Else
 		{
-			Write-Verbose "$(Get-Date): $env:username has Domain Admin rights in the $ADForest Forest"
+			Write-Verbose "$(Get-Date -Format G): $env:username has Domain Admin rights in the $ADForest Forest"
 		}
 		$Script:DARights = $True
 	}
 	Else
 	{
-		#user does nto have Domain Admin rights
+		#user does not have Domain Admin rights
 		If($ADDomain -ne "")
 		{
-			Write-Verbose "$(Get-Date): $env:username does not have Domain Admin rights in the $ADDomain Domain"
+			Write-Verbose "$(Get-Date -Format G): $env:username does not have Domain Admin rights in the $ADDomain Domain"
 		}
 		Else
 		{
-			Write-Verbose "$(Get-Date): $env:username does not have Domain Admin rights in the $ADForest Forest"
+			Write-Verbose "$(Get-Date -Format G): $env:username does not have Domain Admin rights in the $ADForest Forest"
 		}
 	}
 	
@@ -6783,16 +6815,16 @@ Function ProcessScriptSetup
 	{
 		If($Hardware -and -not $Services)
 		{
-			Write-Verbose "$(Get-Date): Hardware inventory requested"
+			Write-Verbose "$(Get-Date -Format G): Hardware inventory requested"
 		}
 		If($Services -and -not $Hardware)
 		{
-			Write-Verbose "$(Get-Date): Services requested"
+			Write-Verbose "$(Get-Date -Format G): Services requested"
 		}
 		
 		If($DCDNSInfo)
 		{
-			Write-Verbose "$(Get-Date): Domain Controller DNS configuration information requested"
+			Write-Verbose "$(Get-Date -Format G): Domain Controller DNS configuration information requested"
 		}
 
 #The following write-host statements should NOT be indented in the code or it messes up how they look in the console when the script runs
@@ -6853,7 +6885,7 @@ please run the script from an elevated PowerShell session using an account with 
 	If($ComputerName -eq "localhost")
 	{
 		$Script:ComputerName = $env:ComputerName
-		Write-Verbose "$(Get-Date): Server name has been changed from localhost to $($ComputerName)"
+		Write-Verbose "$(Get-Date -Format G): Server name has been changed from localhost to $($ComputerName)"
 	}
 	
 	#see if default value of $Env:USERDNSDOMAIN was used
@@ -6865,7 +6897,7 @@ please run the script from an elevated PowerShell session using an account with 
 		If($? -and $Null -ne $Results)
 		{
 			$Script:ComputerName = $Results
-			Write-Verbose "$(Get-Date): Server name has been changed from $Env:USERDNSDOMAIN to $ComputerName"
+			Write-Verbose "$(Get-Date -Format G): Server name has been changed from $Env:USERDNSDOMAIN to $ComputerName"
 		}
 		ElseIf(!$?) #changed for 2.16
 		{
@@ -6875,7 +6907,7 @@ please run the script from an elevated PowerShell session using an account with 
 			If($? -and $Null -ne $Results)
 			{
 				$Script:ComputerName = $Results
-				Write-Verbose "$(Get-Date): Server name has been changed from $Env:USERDNSDOMAIN to $ComputerName"
+				Write-Verbose "$(Get-Date -Format G): Server name has been changed from $Env:USERDNSDOMAIN to $ComputerName"
 			}
 		}
 	}
@@ -6891,7 +6923,7 @@ please run the script from an elevated PowerShell session using an account with 
 		If($? -and $Null -ne $Result)
 		{
 			$Script:ComputerName = $Result.HostName
-			Write-Verbose "$(Get-Date): Server name has been changed from $ip to $ComputerName"
+			Write-Verbose "$(Get-Date -Format G): Server name has been changed from $ip to $ComputerName"
 		}
 		Else
 		{
@@ -6907,11 +6939,11 @@ please run the script from an elevated PowerShell session using an account with 
 	{
 		#get server name
 		#first test to make sure the server is reachable
-		Write-Verbose "$(Get-Date): Testing to see if $ComputerName is online and reachable"
+		Write-Verbose "$(Get-Date -Format G): Testing to see if $ComputerName is online and reachable"
 		If(Test-Connection -ComputerName $ComputerName -quiet -EA 0)
 		{
-			Write-Verbose "$(Get-Date): Server $ComputerName is online."
-			Write-Verbose "$(Get-Date): `tTest #1 to see if $ComputerName is a Domain Controller."
+			Write-Verbose "$(Get-Date -Format G): Server $ComputerName is online."
+			Write-Verbose "$(Get-Date -Format G): `tTest #1 to see if $ComputerName is a Domain Controller."
 			#the server may be online but is it really a domain controller?
 
 			#is the ComputerName in the current domain
@@ -6920,7 +6952,7 @@ please run the script from an elevated PowerShell session using an account with 
 			If(!$? -or $Null -eq $Results)
 			{
 				#try using the Forest name
-				Write-Verbose "$(Get-Date): `tTest #2 to see if $ComputerName is a Domain Controller."
+				Write-Verbose "$(Get-Date -Format G): `tTest #2 to see if $ComputerName is a Domain Controller."
 				$Results = Get-ADDomainController $ComputerName -Server $ADForest -EA 0
 				If(!$?)
 				{
@@ -6938,19 +6970,19 @@ please run the script from an elevated PowerShell session using an account with 
 				}
 				Else
 				{
-					Write-Verbose "$(Get-Date): `tTest #2 succeeded. $ComputerName is a Domain Controller."
+					Write-Verbose "$(Get-Date -Format G): `tTest #2 succeeded. $ComputerName is a Domain Controller."
 				}
 			}
 			Else
 			{
-				Write-Verbose "$(Get-Date): `tTest #1 succeeded. $ComputerName is a Domain Controller."
+				Write-Verbose "$(Get-Date -Format G): `tTest #1 succeeded. $ComputerName is a Domain Controller."
 			}
 			
 			$Results = $Null
 		}
 		Else
 		{
-			Write-Verbose "$(Get-Date): Computer $ComputerName is offline"
+			Write-Verbose "$(Get-Date -Format G): Computer $ComputerName is offline"
 			$ErrorActionPreference = $SaveEAPreference
 			Write-Error "
 			`n`n
@@ -6968,7 +7000,7 @@ please run the script from an elevated PowerShell session using an account with 
 	If($ADForest -ne $ADDomain)
 	{
 		#get forest information so output filename can be generated
-		Write-Verbose "$(Get-Date): Testing to see if $($ADForest) is a valid forest name"
+		Write-Verbose "$(Get-Date -Format G): Testing to see if $($ADForest) is a valid forest name"
 		If([String]::IsNullOrEmpty($ComputerName))
 		{
 			$Script:Forest = Get-ADForest -Identity $ADForest -EA 0
@@ -7010,7 +7042,7 @@ please run the script from an elevated PowerShell session using an account with 
 				Exit
 			}
 		}
-		Write-Verbose "$(Get-Date): $ADForest is a valid forest name"
+		Write-Verbose "$(Get-Date -Format G): $ADForest is a valid forest name"
 		[string]$Script:Title = "AD Inventory Report for the $ADForest Forest"
 		$Script:Domains       = $Script:Forest.Domains | Sort-Object 
 		$Script:ConfigNC      = (Get-ADRootDSE -Server $ADForest -EA 0).ConfigurationNamingContext
@@ -7059,14 +7091,14 @@ please run the script from an elevated PowerShell session using an account with 
 				Exit
 			}
 		}
-		Write-Verbose "$(Get-Date): $ADDomain is a valid domain name"
+		Write-Verbose "$(Get-Date -Format G): $ADDomain is a valid domain name"
 		$Script:Domains       = $results.DNSRoot
 		$Script:DomainDNSRoot = $results.DNSRoot
 		[string]$Script:Title = "AD Inventory Report for the $Script:Domains Domain"
 		
 		$tmp = $results.Forest
 		#get forest info 
-		Write-Verbose "$(Get-Date): Retrieving forest information"
+		Write-Verbose "$(Get-Date -Format G): Retrieving forest information"
 		If([String]::IsNullOrEmpty($ComputerName))
 		{
 			$Script:Forest = Get-ADForest -Identity $tmp -EA 0
@@ -7108,7 +7140,7 @@ please run the script from an elevated PowerShell session using an account with 
 				Exit
 			}
 		}
-		Write-Verbose "$(Get-Date): Found forest information for $tmp"
+		Write-Verbose "$(Get-Date -Format G): Found forest information for $tmp"
 		$Script:ConfigNC = (Get-ADRootDSE -Server $tmp -EA 0).ConfigurationNamingContext
 	}
 	
@@ -7124,7 +7156,7 @@ please run the script from an elevated PowerShell session using an account with 
 #region Forest information
 Function ProcessForestInformation
 {
-	Write-Verbose "$(Get-Date): Writing forest data"
+	Write-Verbose "$(Get-Date -Format G): Writing forest data"
 
 	If($MSWORD -or $PDF)
 	{
@@ -7369,7 +7401,7 @@ Function ProcessForestInformation
 		}
 		$tmp = $Null
 
-		Write-Verbose "$(Get-Date): `t`tCreate Forest Word table"
+		Write-Verbose "$(Get-Date -Format G): `t`tCreate Forest Word table"
 		$Table = AddWordTable -Hashtable $ScriptInformation `
 		-Columns Data,Value `
 		-List `
@@ -7756,7 +7788,7 @@ Function ProcessAllDCsInTheForest
 			[String] $dn	## distinguishedName of a DC
 		)
 
-		#Write-Verbose "$(Get-Date): `t`t`t$dn"
+		#Write-Verbose "$(Get-Date -Format G): `t`t`t$dn"
 		$DCName  = $dn.SubString( 0, $dn.IndexOf( '.' ) )
 		$SrvName = $dn.SubString( $dn.IndexOf( '.' ) + 1 )
 		## SrvName is actually the domain default naming context, e.g.,
@@ -7804,7 +7836,7 @@ Function ProcessAllDCsInTheForest
 		Return $hash
 	} ## end Function GetBasicDCInfo
 
-	Write-Verbose "$(Get-Date): `tDomain controllers"
+	Write-Verbose "$(Get-Date -Format G): `tDomain controllers"
 
 	$txt = "Domain Controllers"
 	If($MSWORD -or $PDF)
@@ -7826,9 +7858,9 @@ Function ProcessAllDCsInTheForest
 	#2.16 change
 	$ADContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext("forest", $Script:Forest.Name)
 	$Forest2 = [system.directoryservices.activedirectory.Forest]::GetForest($ADContext)
-	Write-Verbose "$(Get-Date): `t`tBuild list of Domain controllers in the Forest"
+	Write-Verbose "$(Get-Date -Format G): `t`tBuild list of Domain controllers in the Forest"
 	$AllDCs = @( $Forest2.domains | ForEach-Object {$_.DomainControllers} | ForEach-Object {$_.Name} )
-	Write-Verbose "$(Get-Date): `t`tSort list of all Domain controllers"
+	Write-Verbose "$(Get-Date -Format G): `t`tSort list of all Domain controllers"
 	$AllDCs = @( $AllDCs | Sort-Object )
 	$ADContext = $Null
 	$Forest2 = $Null
@@ -7918,7 +7950,7 @@ Function ProcessAllDCsInTheForest
 
 	If($MSWord -or $PDF)
 	{
-		Write-Verbose "$(Get-Date): `t`tCreate Domain Controller in Forest Word table"
+		Write-Verbose "$(Get-Date -Format G): `t`tCreate Domain Controller in Forest Word table"
 		$Table = AddWordTable -Hashtable $WordTableRowHash `
 		-Columns DCName, GC, ReadOnly, ServerOS, ServerCore `
 		-Headers "Name", "Global Catalog", "Read-only", "Server OS", "Server Core" `
@@ -7967,7 +7999,7 @@ Function ProcessAllDCsInTheForest
 #region process CA information
 Function ProcessCAInformation
 {
-	Write-Verbose "$(Get-Date): `tCA Information"
+	Write-Verbose "$(Get-Date -Format G): `tCA Information"
 	
 	$txt = "Certificate Authority Information"
 	If($MSWORD -or $PDF)
@@ -8016,7 +8048,7 @@ Function ProcessCAInformation
 				[System.Collections.Hashtable[]] $ScriptInformation = @()
 				$ScriptInformation += @{ Data = "Common name"; Value = $obj.cn; }
 				$ScriptInformation += @{ Data = "Distinguished name"; Value = $obj.distinguishedName; }
-				Write-Verbose "$(Get-Date): `t`tCreate Certification Authority Root(s) Word table"
+				Write-Verbose "$(Get-Date -Format G): `t`tCreate Certification Authority Root(s) Word table"
 				$Table = AddWordTable -Hashtable $ScriptInformation `
 				-Columns Data,Value `
 				-List `
@@ -8095,7 +8127,7 @@ Function ProcessCAInformation
 		If($HTML)
 		{
 			WriteHTMLLine 0 0 $txt ''
-			WriteHTMLLine 0 0 ' '
+			#WriteHTMLLine 0 0 ' '
 		}
 	}
 
@@ -8147,7 +8179,7 @@ Function ProcessCAInformation
 				[System.Collections.Hashtable[]] $ScriptInformation = @()
 				$ScriptInformation += @{ Data = "Common name"; Value = $obj.cn; }
 				$ScriptInformation += @{ Data = "Distinguished name"; Value = $obj.distinguishedName; }
-				Write-Verbose "$(Get-Date): `t`tCreate CA Authorities Word table"
+				Write-Verbose "$(Get-Date -Format G): `t`tCreate CA Authorities Word table"
 				$Table = AddWordTable -Hashtable $ScriptInformation `
 				-Columns Data,Value `
 				-List `
@@ -8255,7 +8287,7 @@ Function ProcessCAInformation
 #region process ad optional features
 Function ProcessADOptionalFeatures
 {
-	Write-Verbose "$(Get-Date): `tAD Optional Features"
+	Write-Verbose "$(Get-Date -Format G): `tAD Optional Features"
 	
 	$txt = "AD Optional Features"
 	If($MSWORD -or $PDF)
@@ -8310,7 +8342,7 @@ Function ProcessADOptionalFeatures
 						}
 					}
 				}
-				Write-Verbose "$(Get-Date): `t`tCreate AD Optional Features Word table"
+				Write-Verbose "$(Get-Date -Format G): `t`tCreate AD Optional Features Word table"
 				$Table = AddWordTable -Hashtable $ScriptInformation `
 				-Columns Data,Value `
 				-List `
@@ -8474,7 +8506,7 @@ Function ProcessADSchemaItems
 		)
 	)
 
-	Write-Verbose "$(Get-Date): `tAD Schema Items"
+	Write-Verbose "$(Get-Date -Format G): `tAD Schema Items"
 	
 	$txt = "AD Schema Items"
 	$txt1 = "Just because a schema extension is Present does not mean it is in use."
@@ -8501,7 +8533,7 @@ Function ProcessADSchemaItems
 	$SchemaItems = New-Object System.Collections.ArrayList
 	ForEach( $item in $Name )
 	{
-		Write-Verbose "$(Get-Date): `t`tChecking for $item declared in schema"
+		Write-Verbose "$(Get-Date -Format G): `t`tChecking for $item declared in schema"
 
 		$objDN = 'LDAP://' + 'CN=' + $item + ',' + $schemaNC
 
@@ -8696,7 +8728,7 @@ Function GetSiteLinkOptionText
 
 Function ProcessSiteInformation
 {
-	Write-Verbose "$(Get-Date): Writing sites and services data"
+	Write-Verbose "$(Get-Date -Format G): Writing sites and services data"
 
 	If($MSWORD -or $PDF)
 	{
@@ -8723,7 +8755,7 @@ Function ProcessSiteInformation
 
 	If($? -and $Null -ne $Sites)
 	{
-		Write-Verbose "$(Get-Date): `tProcessing Inter-Site Transports"
+		Write-Verbose "$(Get-Date -Format G): `tProcessing Inter-Site Transports"
 		$AllSiteLinks = Get-ADObject -Searchbase $Script:ConfigNC -Server $ADForest `
 		-Filter 'objectClass -eq "siteLink"' -Property Description, Options, Cost, ReplInterval, SiteList, Schedule -EA 0 `
 		| Select-Object Name, Description, @{Name="SiteCount";Expression={$_.SiteList.Count}}, Cost, ReplInterval, `
@@ -8751,7 +8783,7 @@ Function ProcessSiteInformation
 		{
 			ForEach($SiteLink in $AllSiteLinks)
 			{
-				Write-Verbose "$(Get-Date): `t`tProcessing site link $($SiteLink.Name)"
+				Write-Verbose "$(Get-Date -Format G): `t`tProcessing site link $($SiteLink.Name)"
 				[System.Collections.Hashtable[]] $ScriptInformation = @()
 				$SiteLinkTypeDN = @()
 				$SiteLinkTypeDN = $SiteLink.DistinguishedName.Split(",")
@@ -8800,7 +8832,7 @@ Function ProcessSiteInformation
 					$ScriptInformation += @{ Data = "Options"; Value = $tmp; }
 					$ScriptInformation += @{ Data = "Type"; Value = $SiteLinkType; }
 
-					Write-Verbose "$(Get-Date): `t`t`tCreate Site Links Word table"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tCreate Site Links Word table"
 					$Table = AddWordTable -Hashtable $ScriptInformation `
 					-Columns Data,Value `
 					-List `
@@ -8962,7 +8994,7 @@ Function ProcessSiteInformation
 		
 		ForEach($Site in $Sites)
 		{
-			Write-Verbose "$(Get-Date): `tProcessing site $($Site.Name)"
+			Write-Verbose "$(Get-Date -Format G): `tProcessing site $($Site.Name)"
 			If($MSWord -or $PDF)
 			{
 				WriteWordLine 2 0 "Site: " $Site.Name
@@ -8979,7 +9011,7 @@ Function ProcessSiteInformation
 				WriteHTMLLine 3 0 "Subnets"
 			}
 			
-			Write-Verbose "$(Get-Date): `t`tProcessing subnets"
+			Write-Verbose "$(Get-Date -Format G): `t`tProcessing subnets"
 			$subnetArray = New-Object -Type string[] -ArgumentList $Site.siteObjectBL.Count
 			$i = 0
 			$SitesiteObjectBL = $Site.siteObjectBL
@@ -9022,7 +9054,7 @@ Function ProcessSiteInformation
 				}
 				If($HTML)
 				{
-					Write-Verbose "$(Get-Date): `t`tSite $( $site.Name ) has $( $subnetArray.Count ) subnets"
+					Write-Verbose "$(Get-Date -Format G): `t`tSite $( $site.Name ) has $( $subnetArray.Count ) subnets"
 					$rowdata = New-Object System.Array[] $subnetArray.Count
 					$rowIndx = 0
 
@@ -9040,7 +9072,7 @@ Function ProcessSiteInformation
 				}
 			}
 			
-			Write-Verbose "$(Get-Date): `t`tProcessing servers"
+			Write-Verbose "$(Get-Date -Format G): `t`tProcessing servers"
 			If($MSWord -or $PDF)
 			{
 				WriteWordLine 3 0 "Servers"
@@ -9056,7 +9088,7 @@ Function ProcessSiteInformation
 			$siteName = $Site.Name
 			
 			#build array of connect objects
-			Write-Verbose "$(Get-Date): `t`t`tProcessing automatic connection objects"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tProcessing automatic connection objects"
 			$Connections = New-Object System.Collections.ArrayList
 			$ConnectionObjects = Get-ADObject -Filter 'objectClass -eq "nTDSConnection" -and options -bor 1' -Searchbase $Script:ConfigNC -Property DistinguishedName, fromServer -Server $ADForest -EA 0
 			
@@ -9085,7 +9117,7 @@ Function ProcessSiteInformation
 				}
 			}
 			
-			Write-Verbose "$(Get-Date): `t`t`tProcessing manual connection objects"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tProcessing manual connection objects"
 			$ConnectionObjects = $Null
 			$ConnectionObjects = Get-ADObject -Filter 'objectClass -eq "nTDSConnection" -and -not options -bor 1' -Searchbase $Script:ConfigNC -Property Name, DistinguishedName, fromServer -Server $ADForest -EA 0
 			
@@ -9216,7 +9248,7 @@ Function ProcessSiteInformation
 					If($HTML)
 					{
 						WriteHTMLLine 0 0 $SiteServer.DNSHostName
-						WriteHTMLLine 0 0 " "
+						#WriteHTMLLine 0 0 " "
 						#for each server list each connection object
 						If($Null -ne $Connections)
 						{
@@ -9350,7 +9382,7 @@ Function ProcessSiteInformation
 #region domains
 Function ProcessDomains
 {
-	Write-Verbose "$(Get-Date): Writing domain data"
+	Write-Verbose "$(Get-Date -Format G): Writing domain data"
 
 	If($MSWORD -or $PDF)
 	{
@@ -9409,14 +9441,16 @@ Function ProcessDomains
 	"15325" = "Exchange 2016 CU2";
 	"15326" = "Exchange 2016 CU3/CU4/CU5"; #added in 2.16
 	"15330" = "Exchange 2016 CU6"; #added in 2.16
-	"15332" = "Exchange 2016 CU7 through CU15"; #added in 2.16 and updated in 2.20, updated in 2.22, updated in 2.24
+	"15332" = "Exchange 2016 CU7 through CU18"; #added in 2.16 and updated in 2.20, updated in 2.22, updated in 2.24, updated in 3.02
+	"15333" = "Exchange 2016 CU19"; #added in 3.02
 	"17000" = "Exchange 2019 RTM/CU1"; #added in 2.22, updated in 2.24
-	"17001" = "Exchange 2019 CU2-CU4"; #added in 2.24
+	"17001" = "Exchange 2019 CU2-CU7"; #added in 2.24, updated in 3.02
+	"17002" = "Exchange 2019 CU8"; #added in 3.02
 	}
 
 	ForEach($Domain in $Script:Domains)
 	{
-		Write-Verbose "$(Get-Date): `tProcessing domain $($Domain)"
+		Write-Verbose "$(Get-Date -Format G): `tProcessing domain $($Domain)"
 
 		$DomainInfo = Get-ADDomain -Identity $Domain -EA 0
 
@@ -10029,12 +10063,12 @@ Function ProcessDomains
 				
 				$columnWidths = @("250","300")
 				FormatHTMLTable -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "550"
-				WriteHTMLLine 0 0 ' '
+				#WriteHTMLLine 0 0 ' '
 
 				$rowData = $null
 			}
 
-			Write-Verbose "$(Get-Date): `t`tGetting domain trusts"
+			Write-Verbose "$(Get-Date -Format G): `t`tGetting domain trusts"
 			If($MSWord -or $PDF)
 			{
 				WriteWordLine 3 0 "Domain Trusts"
@@ -10220,7 +10254,7 @@ Function ProcessDomains
 				}
 			}
 			
-			Write-Verbose "$(Get-Date): `t`tProcessing domain controllers"
+			Write-Verbose "$(Get-Date -Format G): `t`tProcessing domain controllers"
 			$DomainControllers = $Null
 			$DomainControllers = Get-ADDomainController -Filter * -Server $DomainInfo.DNSRoot -EA 0 | Sort-Object Name
 			
@@ -10316,7 +10350,7 @@ Function ProcessDomains
 				}
 			}
 
-			Write-Verbose "$(Get-Date): `t`tProcessing Fine Grained Password Policies"
+			Write-Verbose "$(Get-Date -Format G): `t`tProcessing Fine Grained Password Policies"
 			
 			#are FGPP cmdlets available
 			If(Get-Command -Name "Get-ADFineGrainedPasswordPolicy" -ea 0)
@@ -10801,7 +10835,7 @@ Function ProcessDomains
 #region domain controllers
 Function ProcessDomainControllers
 {
-	Write-Verbose "$(Get-Date): Writing domain controller data"
+	Write-Verbose "$(Get-Date -Format G): Writing domain controller data"
 
 	If($MSWORD -or $PDF)
 	{
@@ -10822,7 +10856,7 @@ Function ProcessDomainControllers
 
 	ForEach($DC in $Script:AllDomainControllers)
 	{
-		Write-Verbose "$(Get-Date): `tProcessing domain controller $($DC.name)"
+		Write-Verbose "$(Get-Date -Format G): `tProcessing domain controller $($DC.name)"
 		$FSMORoles = $DC.OperationMasterRoles | Sort-Object 
 		$Partitions = $DC.Partitions | Sort-Object 
 		
@@ -11183,7 +11217,7 @@ Function ProcessDomainControllers
 			
 			$columnWidths = @("175","300")
 			FormatHTMLTable -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "475"
-			WriteHTMLLine 0 0 ' '
+			#WriteHTMLLine 0 0 ' '
 
 			$rowData = $null
 		}
@@ -11295,7 +11329,7 @@ Function OutputTimeServerRegistryKeys
 		[String] $DCName
 	)
 	
-	Write-Verbose "$(Get-Date): `tTimeServer Registry Keys"
+	Write-Verbose "$(Get-Date -Format G): `tTimeServer Registry Keys"
 	#HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\Config	AnnounceFlags
 	#HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\Config	MaxNegPhaseCorrection
 	#HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\Config	MaxPosPhaseCorrection
@@ -11325,7 +11359,7 @@ Function OutputTimeServerRegistryKeys
 		$NtpType = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\Parameters" "Type" $DCName
 		$SpecialPollInterval = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\NtpClient" "SpecialPollInterval" $DCName
 		$VMICTimeProviderEnabled = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\VMICTimeProvider" "Enabled" $DCName
-		$NTPSource = w32tm /query /computer:$DCName /source
+		$NTPSource = Invoke-Command -ComputerName $DCName {w32tm /query /computer:$DCName /source}
 	}
 
 	If( $VMICTimeProviderEnabled -eq 'n/a' )
@@ -11467,7 +11501,7 @@ Function OutputADFileLocations
 		[String] $DCName 
 	)
 	
-	Write-Verbose "$(Get-Date): `tAD Database, Logfile and SYSVOL locations"
+	Write-Verbose "$(Get-Date -Format G): `tAD Database, Logfile and SYSVOL locations"
 	#HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NTDS\Parameters	'DSA Database file'
 	#HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NTDS\Parameters	'Database log files path'
 	#HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters	SysVol
@@ -11582,7 +11616,7 @@ Function OutputEventLogInfo
 		[String] $DCName 
 	)
 	
-	Write-Verbose "$(Get-Date): `tEvent Log Information"
+	Write-Verbose "$(Get-Date -Format G): `tEvent Log Information"
 	$ELInfo = $null ## New-Object System.Collections.ArrayList ## FIXME - make this an array instead of arraylist
 	
 	#V3.00 - note that we are sorted here by name, don't need to sort again later.
@@ -11738,7 +11772,7 @@ Function OutputEventLogInfo
 #region organizational units
 Function ProcessOrganizationalUnits
 {
-	Write-Verbose "$(Get-Date): Writing OU data by Domain"
+	Write-Verbose "$(Get-Date -Format G): Writing OU data by Domain"
 	If($MSWORD -or $PDF)
 	{
 		$Script:selection.InsertNewPage()
@@ -11756,7 +11790,7 @@ Function ProcessOrganizationalUnits
 
 	ForEach($Domain in $Script:Domains)
 	{
-		Write-Verbose "$(Get-Date): `tProcessing domain $($Domain)"
+		Write-Verbose "$(Get-Date -Format G): `tProcessing domain $($Domain)"
 		
 		If(($MSWORD -or $PDF) -and !$First)
 		{
@@ -11854,8 +11888,8 @@ Function ProcessOrganizationalUnits
 		If($MSWORD -or $PDF)
 		{
 			$ItemsWordTable = New-Object System.Collections.ArrayList
-			$HighlightedCells = New-Object System.Collections.ArrayList
-			[int] $CurrentServiceIndex = 2;
+			$WordHighlightedCells = New-Object System.Collections.ArrayList
+			[int] $CurrentServiceIndex = 2
 		}
 		If($Text)
 		{
@@ -11887,7 +11921,7 @@ Function ProcessOrganizationalUnits
 		{
 			$OUCount++
 			$OUDisplayName = $OU.CanonicalName.SubString($OU.CanonicalName.IndexOf("/")+1)
-			Write-Verbose "$(Get-Date): `t`tProcessing OU $($OU.CanonicalName) - OU # $OUCount of $NumOUs"
+			Write-Verbose "$(Get-Date -Format G): `t`tProcessing OU $($OU.CanonicalName) - OU # $OUCount of $NumOUs"
 			
 			#get counts of users, computers and groups in the OU
 			
@@ -11938,7 +11972,7 @@ Function ProcessOrganizationalUnits
 				## Store "to highlight" cell references
 				If($Tmp -eq "No") 
 				{
-					$HighlightedCells.Add(@{ Row = $CurrentServiceIndex; Column = 3; }) > $Null
+					$WordHighlightedCells.Add(@{ Row = $CurrentServiceIndex; Column = 3; }) > $Null
 				}
 				$CurrentServiceIndex++;
 			}
@@ -11965,16 +11999,21 @@ Function ProcessOrganizationalUnits
 			}
 			If($HTML)
 			{
-				$Protected = 'No'
 				If( $OU.ProtectedFromAccidentalDeletion -eq $True )
 				{
 					$Protected = 'Yes'
+					$HTMLHighlightedCells = $htmlwhite
 				}
+				Else
+				{
+					$Protected = 'No'
+					$HTMLHighlightedCells = $htmlred
+				} 
 
 				$rowData[ $rowIndex ] = @(
 					$OUDisplayName,         $htmlwhite,
 					$OU.Created.ToString(), $htmlwhite,
-					$Protected,             $htmlwhite,
+					$Protected,             $HTMLHighlightedCells,
 					$UserCountStr,          $htmlwhite,
 					$ComputerCountStr,      $htmlwhite,
 					$GroupCountStr,         $htmlwhite
@@ -11997,10 +12036,8 @@ Function ProcessOrganizationalUnits
 			-AutoFit $wdAutoFitFixed;
 
 			SetWordCellFormat -Collection $Table -Size 9 -BackgroundColor $wdColorWhite
-			## IB - Set the header row format after the SetWordTableAlternateRowColor Function as it will paint the header row!
 			SetWordCellFormat -Collection $Table.Rows.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
-			## IB - Set the required highlighted cells
-			SetWordCellFormat -Coordinates $HighlightedCells -Table $Table -Bold -BackgroundColor $wdColorRed -Solid;
+			SetWordCellFormat -Coordinates $WordHighlightedCells -Table $Table -Bold -BackgroundColor $wdColorRed -Solid;
 
 			$Table.Columns.Item(1).Width = 125
 			$Table.Columns.Item(2).Width = 100
@@ -12067,7 +12104,7 @@ Function ProcessGroupInformation
 {
 	## FIXME - v3.00 see optimizations applied to getDSUsers
 	
-	Write-Verbose "$(Get-Date): Writing group data"
+	Write-Verbose "$(Get-Date -Format G): Writing group data"
 
 	If($MSWORD -or $PDF)
 	{
@@ -12087,7 +12124,7 @@ Function ProcessGroupInformation
 
 	ForEach($Domain in $Script:Domains)
 	{
-		Write-Verbose "$(Get-Date): `tProcessing groups in domain $($Domain)"
+		Write-Verbose "$(Get-Date -Format G): `tProcessing groups in domain $($Domain)"
 		If(($MSWORD -or $PDF) -and !$First)
 		{
 			#put each domain, starting with the second, on a new page
@@ -12175,7 +12212,7 @@ Function ProcessGroupInformation
 		{
 			#get counts
 			
-			Write-Verbose "$(Get-Date): `t`tGetting counts"
+			Write-Verbose "$(Get-Date -Format G): `t`tGetting counts"
 			
 			[int]$SecurityCount = 0
 			[int]$DistributionCount = 0
@@ -12185,39 +12222,39 @@ Function ProcessGroupInformation
 			[int]$ContactsCount = 0
 			[int]$GroupsWithSIDHistory = 0
 			
-			Write-Verbose "$(Get-Date): `t`t`tSecurity Groups"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tSecurity Groups"
 			$Results = @($groups | Where-Object {$_.groupcategory -eq "Security"})
 			
 			[int]$SecurityCount = $Results.Count
 			
-			Write-Verbose "$(Get-Date): `t`t`tDistribution Groups"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tDistribution Groups"
 			$Results = @($groups | Where-Object {$_.groupcategory -eq "Distribution"})
 			
 			[int]$DistributionCount = $Results.Count
 
-			Write-Verbose "$(Get-Date): `t`t`tGlobal Groups"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tGlobal Groups"
 			$Results = @($groups | Where-Object {$_.groupscope -eq "Global"})
 
 			[int]$GlobalCount = $Results.Count
 
-			Write-Verbose "$(Get-Date): `t`t`tUniversal Groups"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tUniversal Groups"
 			$Results = @($groups | Where-Object {$_.groupscope -eq "Universal"})
 
 			[int]$UniversalCount = $Results.Count
 			
-			Write-Verbose "$(Get-Date): `t`t`tDomain Local Groups"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tDomain Local Groups"
 			$Results = @($groups | Where-Object {$_.groupscope -eq "DomainLocal"})
 
 			[int]$DomainLocalCount = $Results.Count
 
-			Write-Verbose "$(Get-Date): `t`t`tGroups with SID History"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tGroups with SID History"
 			$Results = $Null
 			$Results = @( Get-ADObject -LDAPFilter "(sIDHistory=*)" -Server $Domain -Property objectClass, sIDHistory -EA 0 )
 			$groups  = @( $Results | Where-Object {$_.objectClass -eq 'group'} )
 
 			[int]$GroupsWithSIDHistory = $groups.Count
 
-			Write-Verbose "$(Get-Date): `t`t`tContacts"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tContacts"
 			$Results = $Null
 			$Results = @(Get-ADObject -LDAPFilter "objectClass=Contact" -Server $Domain -EA 0)
 
@@ -12232,7 +12269,7 @@ Function ProcessGroupInformation
 			[string]$GroupsWithSIDHistoryStr = "{0,7:N0}" -f $GroupsWithSIDHistory
 			[string]$ContactsCountStr = "{0,7:N0}" -f $ContactsCount
 			
-			Write-Verbose "$(Get-Date): `t`tBuild groups table"
+			Write-Verbose "$(Get-Date -Format G): `t`tBuild groups table"
 			If($MSWORD -or $PDF)
 			{
 				$TableRange = $Script:doc.Application.Selection.Range
@@ -12345,7 +12382,7 @@ Function ProcessGroupInformation
 				$SchemaAdminsSID = $Null
 			}
 			
-			Write-Verbose "$(Get-Date): `t`tListing domain admins"
+			Write-Verbose "$(Get-Date -Format G): `t`tListing domain admins"
 			$Admins = $Null
 			$Admins = @(Get-ADGroupMember -Identity $DomainAdminsSID -Server $Domain -EA 0)
 			
@@ -12360,7 +12397,7 @@ Function ProcessGroupInformation
 					WriteWordLine 3 0 "Privileged Groups"
 					WriteWordLine 4 0 "Domain Admins ($($AdminsCountStr) members):"
 					$TableRange = $Script:doc.Application.Selection.Range
-					[int]$Columns = 4
+					[int]$Columns = 5
 					[int]$Rows = $AdminsCount + 1
 					[int]$xRow = 1
 					$Table = $Script:doc.Tables.Add($TableRange, $Rows, $Columns)
@@ -12375,11 +12412,13 @@ Function ProcessGroupInformation
 					$Table.Cell($xRow,1).Range.Font.Bold = $True
 					$Table.Cell($xRow,1).Range.Text = "Name"
 					$Table.Cell($xRow,2).Range.Font.Bold = $True
-					$Table.Cell($xRow,2).Range.Text = "Password Last Changed"
+					$Table.Cell($xRow,2).Range.Text = "Domain"
 					$Table.Cell($xRow,3).Range.Font.Bold = $True
-					$Table.Cell($xRow,3).Range.Text = "Password Never Expires"
+					$Table.Cell($xRow,3).Range.Text = "Password Last Changed"
 					$Table.Cell($xRow,4).Range.Font.Bold = $True
-					$Table.Cell($xRow,4).Range.Text = "Account Enabled"
+					$Table.Cell($xRow,4).Range.Text = "Password Never Expires"
+					$Table.Cell($xRow,5).Range.Font.Bold = $True
+					$Table.Cell($xRow,5).Range.Text = "Account Enabled"
 				}
 				If($Text)
 				{
@@ -12632,7 +12671,7 @@ Function ProcessGroupInformation
 
 			If($Domain -eq $Script:ForestRootDomain)
 			{
-				Write-Verbose "$(Get-Date): `t`tListing enterprise admins"
+				Write-Verbose "$(Get-Date -Format G): `t`tListing enterprise admins"
 			
 				$Admins = @(Get-ADGroupMember -Identity $EnterpriseAdminsSID -Server $Domain -EA 0)
 				
@@ -12927,7 +12966,7 @@ Function ProcessGroupInformation
 			
 			If($Domain -eq $Script:ForestRootDomain)
 			{
-				Write-Verbose "$(Get-Date): `t`tListing schema admins"
+				Write-Verbose "$(Get-Date -Format G): `t`tListing schema admins"
 			
 				$Admins = @(Get-ADGroupMember -Identity $SchemaAdminsSID -Server $Domain -EA 0)
 				
@@ -13214,7 +13253,7 @@ Function ProcessGroupInformation
 				}
 			}
 
-			Write-Verbose "$(Get-Date): `t`tListing users with AdminCount=1"
+			Write-Verbose "$(Get-Date -Format G): `t`tListing users with AdminCount=1"
 			$AdminCounts = @(Get-ADUser -LDAPFilter "(admincount=1)"  -Server $Domain -EA 0)
 			
 			If($? -and $Null -ne $AdminCounts)
@@ -13455,7 +13494,7 @@ Function ProcessGroupInformation
 				}
 			}
 			
-			Write-Verbose "$(Get-Date): `t`tListing groups with AdminCount=1"
+			Write-Verbose "$(Get-Date -Format G): `t`tListing groups with AdminCount=1"
 			$AdminCounts = @(Get-ADGroup -LDAPFilter "(admincount=1)" -Server $Domain -EA 0 | Select-Object Name)
 			
 			If($? -and $Null -ne $AdminCounts)
@@ -13496,7 +13535,7 @@ Function ProcessGroupInformation
 				}
 				ForEach($Admin in $AdminCounts)
 				{
-					Write-Verbose "$(Get-Date): `t`t`t$($Admin.Name)"
+					Write-Verbose "$(Get-Date -Format G): `t`t`t$($Admin.Name)"
 					If($MSWord -or $PDF)
 					{
 						$xRow++
@@ -13670,7 +13709,7 @@ Function ProcessGroupInformation
 #region GPOs by domain
 Function ProcessGPOsByDomain
 {
-	Write-Verbose "$(Get-Date): Writing domain group policy data"
+	Write-Verbose "$(Get-Date -Format G): Writing domain group policy data"
 
 	If($MSWORD -or $PDF)
 	{
@@ -13689,7 +13728,7 @@ Function ProcessGPOsByDomain
 
 	ForEach($Domain in $Script:Domains)
 	{
-		Write-Verbose "$(Get-Date): `tProcessing group policies for domain $($Domain)"
+		Write-Verbose "$(Get-Date -Format G): `tProcessing group policies for domain $($Domain)"
 
 		$DomainInfo = Get-ADDomain -Identity $Domain -EA 0 
 
@@ -13760,7 +13799,7 @@ Function ProcessGPOsByDomain
 			WriteHTMLLine 3 0 "Linked Group Policy Objects" 
 		}
 
-		Write-Verbose "$(Get-Date): `t`tGetting linked GPOs"
+		Write-Verbose "$(Get-Date -Format G): `t`tGetting linked GPOs"
 
 		$LinkedGPOs = @($DomainInfo.LinkedGroupPolicyObjects | Sort-Object)
 		If($Null -eq $LinkedGpos)
@@ -13878,7 +13917,7 @@ Function ProcessGPOsByDomain
 #region group policies by organizational units
 Function ProcessgGPOsByOUOld
 {
-	Write-Verbose "$(Get-Date): Writing Group Policy data by Domain by OU"
+	Write-Verbose "$(Get-Date -Format G): Writing Group Policy data by Domain by OU"
 	If($MSWORD -or $PDF)
 	{
 		$Script:selection.InsertNewPage()
@@ -13896,7 +13935,7 @@ Function ProcessgGPOsByOUOld
 
 	ForEach($Domain in $Script:Domains)
 	{
-		Write-Verbose "$(Get-Date): `tProcessing domain $($Domain)"
+		Write-Verbose "$(Get-Date -Format G): `tProcessing domain $($Domain)"
 		If(($MSWORD -or $PDF) -and !$First)
 		{
 			#put each domain, starting with the second, on a new page
@@ -13945,7 +13984,7 @@ Function ProcessgGPOsByOUOld
 		}
 		
 		#V3.00
-		Write-Verbose "$(Get-Date): `tSearching for all OUs in domain $($Domain)"
+		Write-Verbose "$(Get-Date -Format G): `tSearching for all OUs in domain $($Domain)"
 
 		## FIXME - we get "all OUs for the domain" three times in this script - that needs to be fixed.
 		## [Webster] not really. ProcessGPOsByOUNew and ProcessGPOsByOUOld are separate Functions and never used in the same script run
@@ -13989,7 +14028,7 @@ Function ProcessgGPOsByOUOld
 		{
 			$OUCount++
 			$OUDisplayName = $OU.CanonicalName.SubString($OU.CanonicalName.IndexOf("/")+1)
-			Write-Verbose "$(Get-Date): `t`tProcessing OU $($OU.CanonicalName) - OU # $OUCount of $NumOUs"
+			Write-Verbose "$(Get-Date -Format G): `t`tProcessing OU $($OU.CanonicalName) - OU # $OUCount of $NumOUs"
 			
 			#V3.00 FIXME MAYBE???? LinkedGroupPolicyObjects
 			#get data for the individual OU
@@ -14036,7 +14075,7 @@ Function ProcessgGPOsByOUOld
 				Continue
 			}
 	
-			Write-Verbose "$(Get-Date): `t`t`tGetting linked GPOs"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tGetting linked GPOs"
 			[array]$LinkedGPOs = $OUInfo.LinkedGroupPolicyObjects
 			If($LinkedGpos.Count -eq 0)
 			{
@@ -14158,7 +14197,7 @@ Function ProcessgGPOsByOUOld
 
 Function ProcessgGPOsByOUNew
 {
-	Write-Verbose "$(Get-Date): Writing Group Policy data by Domain by OU"
+	Write-Verbose "$(Get-Date -Format G): Writing Group Policy data by Domain by OU"
 	If($MSWORD -or $PDF)
 	{
 		$Script:selection.InsertNewPage()
@@ -14176,7 +14215,7 @@ Function ProcessgGPOsByOUNew
 
 	ForEach($Domain in $Script:Domains)
 	{
-		Write-Verbose "$(Get-Date): `tProcessing domain $($Domain)"
+		Write-Verbose "$(Get-Date -Format G): `tProcessing domain $($Domain)"
 		If(($MSWORD -or $PDF) -and !$First)
 		{
 			#put each domain, starting with the second, on a new page
@@ -14225,7 +14264,7 @@ Function ProcessgGPOsByOUNew
 		}
 
 		#V3.00
-		Write-Verbose "$(Get-Date): `tSearching for all OUs in domain $($Domain)"
+		Write-Verbose "$(Get-Date -Format G): `tSearching for all OUs in domain $($Domain)"
 
 		#get all OUs for the domain
 		$OUs = @(Get-ADOrganizationalUnit -Filter * -Server $Domain `
@@ -14276,14 +14315,14 @@ Function ProcessgGPOsByOUNew
 		[int]$OUCount = 0
 
 		#V3.00
-		Write-Verbose "$(Get-Date): `tThere are $NumOUs OUs in domain $($Domain)"
+		Write-Verbose "$(Get-Date -Format G): `tThere are $NumOUs OUs in domain $($Domain)"
 
 		ForEach($OU in $OUs)
 		{
 			$OUCount++
 			$OUDisplayName = $OU.CanonicalName.SubString($OU.CanonicalName.IndexOf("/")+1)
-			Write-Verbose "$(Get-Date): `t`tProcessing OU $($OU.CanonicalName) - OU # $OUCount of $NumOUs"
-			Write-Verbose "$(Get-Date): `t`t`tGetting linked and inherited GPOs"
+			Write-Verbose "$(Get-Date -Format G): `t`tProcessing OU $($OU.CanonicalName) - OU # $OUCount of $NumOUs"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tGetting linked and inherited GPOs"
 
 			#change for 2.16
 			#work around invalid property DisplayName when the gpolinks and inheritedgpolinks collections are empty
@@ -14563,7 +14602,7 @@ Function getDSUsers
 	$null         = GetMaximumPasswordAge
 	$now          = Get-Date
 
-    Write-Verbose "$(Get-Date): `t`tGathering user misc data"
+    Write-Verbose "$(Get-Date -Format G): `t`tGathering user misc data"
 
     ## see MBS Get-myUserInfo.ps1 for the full list
     $ADS_UF_ACCOUNTDISABLE                          = 2        ### 0x2
@@ -14634,20 +14673,20 @@ Function getDSUsers
 
     If( $ctUsers -eq 0 )
     {
-        Write-Verbose "$(Get-Date): `t`tNo users found, exiting"
+        Write-Verbose "$(Get-Date -Format G): `t`tNo users found, exiting"
 
         Return
     }
 
     If( $ctUsers -gt 50000 )
     {
-        Write-Verbose "$(Get-Date): `t`t`t******************************************************************************************************"
-        Write-Verbose "$(Get-Date): `t`t`tThere are $ctUsers user accounts to process. Building user lists will take a long time. Be patient."
-        Write-Verbose "$(Get-Date): `t`t`t******************************************************************************************************"
+        Write-Verbose "$(Get-Date -Format G): `t`t`t******************************************************************************************************"
+        Write-Verbose "$(Get-Date -Format G): `t`t`tThere are $ctUsers user accounts to process. Building user lists will take a long time. Be patient."
+        Write-Verbose "$(Get-Date -Format G): `t`t`t******************************************************************************************************"
     }
     Else
     {
-        Write-Verbose "$(Get-Date): Processing $ctUsers user objects in the $domain Domain..."        
+        Write-Verbose "$(Get-Date -Format G): Processing $ctUsers user objects in the $domain Domain..."        
     }
     
     $ctUsersDisabled              = 0
@@ -14693,7 +14732,7 @@ Function getDSUsers
         $ctIndex++
         If( ( $ctIndex % 5000 ) -eq 0 )
         {
-            Write-Verbose "$(Get-Date): about to process user $ctIndex of $ctUsers"
+            Write-Verbose "$(Get-Date -Format G): about to process user $ctIndex of $ctUsers"
         }
 
         $distinguishedname  = If( $null -ne ( $obj = $objResult.Properties[ 'distinguishedname' ] ) -and $obj.Count -gt 0 ) 
@@ -14947,32 +14986,32 @@ Function getDSUsers
         }
     }
 
-    Write-Verbose "$(Get-Date): `t`tGetDSUsers main processing done"
+    Write-Verbose "$(Get-Date -Format G): `t`tGetDSUsers main processing done"
 
     <#
-	Write-Verbose "$(Get-Date): ctUsers                $ctUsers"
-    Write-Verbose "$(Get-Date): ctUsersDisabled        $ctUsersDisabled"
-    Write-Verbose "$(Get-Date): ctUsersUnknown         $ctUsersUnknown"
-    Write-Verbose "$(Get-Date): ctUsersLockedOut       $ctUsersLockedOut"
-    Write-Verbose "$(Get-Date): ctPasswordExpired      $ctPasswordExpired"
-    Write-Verbose "$(Get-Date): ctPasswordNeverExpires $ctPasswordNeverExpires"
-    Write-Verbose "$(Get-Date): ctPasswordNotRequired  $ctPasswordNotRequired"
-    Write-Verbose "$(Get-Date): ctCannotChangePassword $ctCannotChangePassword"
-    Write-Verbose "$(Get-Date): ctNolastLogonTimestamp $ctNolastLogonTimestamp"
-    Write-Verbose "$(Get-Date): ctHasSIDHistory        $ctHasSIDHistory"
-    Write-Verbose "$(Get-Date): ctHomeDrive            $ctHomeDrive"
-    Write-Verbose "$(Get-Date): ctPrimaryGroup         $ctPrimaryGroup"
-    Write-Verbose "$(Get-Date): ctRDSHomeDrive         $ctRDSHomeDrive"
+	Write-Verbose "$(Get-Date -Format G): ctUsers                $ctUsers"
+    Write-Verbose "$(Get-Date -Format G): ctUsersDisabled        $ctUsersDisabled"
+    Write-Verbose "$(Get-Date -Format G): ctUsersUnknown         $ctUsersUnknown"
+    Write-Verbose "$(Get-Date -Format G): ctUsersLockedOut       $ctUsersLockedOut"
+    Write-Verbose "$(Get-Date -Format G): ctPasswordExpired      $ctPasswordExpired"
+    Write-Verbose "$(Get-Date -Format G): ctPasswordNeverExpires $ctPasswordNeverExpires"
+    Write-Verbose "$(Get-Date -Format G): ctPasswordNotRequired  $ctPasswordNotRequired"
+    Write-Verbose "$(Get-Date -Format G): ctCannotChangePassword $ctCannotChangePassword"
+    Write-Verbose "$(Get-Date -Format G): ctNolastLogonTimestamp $ctNolastLogonTimestamp"
+    Write-Verbose "$(Get-Date -Format G): ctHasSIDHistory        $ctHasSIDHistory"
+    Write-Verbose "$(Get-Date -Format G): ctHomeDrive            $ctHomeDrive"
+    Write-Verbose "$(Get-Date -Format G): ctPrimaryGroup         $ctPrimaryGroup"
+    Write-Verbose "$(Get-Date -Format G): ctRDSHomeDrive         $ctRDSHomeDrive"
 
-    Write-Verbose "$(Get-Date): ctActiveUsers                $ctActiveUsers"
-    Write-Verbose "$(Get-Date): ctActivePasswordExpired      $ctActivePasswordExpired"
-    Write-Verbose "$(Get-Date): ctActivePasswordNeverExpires $ctActivePasswordNeverExpires"
-    Write-Verbose "$(Get-Date): ctActivePasswordNotRequired  $ctActivePasswordNotRequired"
-    Write-Verbose "$(Get-Date): ctActiveCannotChangePassword $ctActiveCannotChangePassword"
-    Write-Verbose "$(Get-Date): ctActiveNolastLogonTimestamp $ctActiveNolastLogonTimestamp"
+    Write-Verbose "$(Get-Date -Format G): ctActiveUsers                $ctActiveUsers"
+    Write-Verbose "$(Get-Date -Format G): ctActivePasswordExpired      $ctActivePasswordExpired"
+    Write-Verbose "$(Get-Date -Format G): ctActivePasswordNeverExpires $ctActivePasswordNeverExpires"
+    Write-Verbose "$(Get-Date -Format G): ctActivePasswordNotRequired  $ctActivePasswordNotRequired"
+    Write-Verbose "$(Get-Date -Format G): ctActiveCannotChangePassword $ctActiveCannotChangePassword"
+    Write-Verbose "$(Get-Date -Format G): ctActiveNolastLogonTimestamp $ctActiveNolastLogonTimestamp"
 
-    Write-Verbose "$(Get-Date): `t`tGetDSUsers end"
-    Write-Verbose "$(Get-Date): `t`tFormat numbers into strings"
+    Write-Verbose "$(Get-Date -Format G): `t`tGetDSUsers end"
+    Write-Verbose "$(Get-Date -Format G): `t`tFormat numbers into strings"
 	#>
 
     ## I pre-format the numbers because all 3 of the output formats were doing
@@ -15068,7 +15107,7 @@ Function getDSUsers
     }
 	If($HTML)
 	{
-		Write-Verbose "$(Get-Date): `t`tBuild table for All Users"
+		Write-Verbose "$(Get-Date -Format G): `t`tBuild table for All Users"
 		WriteHTMLLine 3 0 'All Users'
 		#V3.00 pre-allocate rowdata
 		## $rowdata = @()
@@ -15166,7 +15205,7 @@ Function getDSUsers
 			WriteHTMLLine 0 0 "* This may be a permissions issue if this is a Trusted Forest." -options $htmlBold
 		}
 		
-		Write-Verbose "$(Get-Date): `t`tBuild table for Active Users"
+		Write-Verbose "$(Get-Date -Format G): `t`tBuild table for Active Users"
 		WriteHTMLLine 3 0 "Active Users"
 
 		#V3.00 pre-allocate rowdata
@@ -15221,7 +15260,7 @@ Function getDSUsers
 	}
 	If($MSWORD -or $PDF)
 	{
-		Write-Verbose "$(Get-Date): `t`tBuild table for All Users"
+		Write-Verbose "$(Get-Date -Format G): `t`tBuild table for All Users"
 		WriteWordLine 3 0 'All Users'
 		$TableRange   = $Script:doc.Application.Selection.Range
 		[int]$Columns = 3
@@ -15355,7 +15394,7 @@ Function getDSUsers
 			WriteWordLine 0 0 "* This may be a permissions issue if this is a Trusted Forest." "" $Null 8 $False $True
 		}
 		
-		Write-Verbose "$(Get-Date): `t`tBuild table for Active Users"
+		Write-Verbose "$(Get-Date -Format G): `t`tBuild table for Active Users"
 		WriteWordLine 3 0 "Active Users"
 		$TableRange   = $Script:doc.Application.Selection.Range
 		[int]$Columns = 3
@@ -15492,12 +15531,12 @@ Function getDSUsers
     #$script_end = Get-Date
     #$script_delta = $script_end - $script_begin
 	#$elapsed = 'Elapsed: ' + $script_delta.Hours.ToString() + '.' + $script_delta.Minutes.ToString() + '.' + $script_delta.Seconds.ToString()
-	#Write-Verbose "$(Get-Date):`tEnd GetDSusers TrustedDomain $TrustedDomain, Elapsed $elapsed"
+	#Write-Verbose "$(Get-Date -Format G):`tEnd GetDSusers TrustedDomain $TrustedDomain, Elapsed $elapsed"
 }
 
 Function ProcessMiscDataByDomain
 {
-	Write-Verbose "$(Get-Date): Writing miscellaneous data by domain"
+	Write-Verbose "$(Get-Date -Format G): Writing miscellaneous data by domain"
 
 	If($MSWORD -or $PDF)
 	{
@@ -15517,7 +15556,7 @@ Function ProcessMiscDataByDomain
 
 	ForEach($Domain in $Script:Domains)
 	{
-		Write-Verbose "$(Get-Date): `tProcessing misc data for domain $($Domain)"
+		Write-Verbose "$(Get-Date -Format G): `tProcessing misc data for domain $($Domain)"
 
 		$DomainInfo = Get-ADDomain -Identity $Domain -EA 0 
 
@@ -15585,7 +15624,7 @@ Function ProcessMiscDataByDomain
 			WriteHTMLLine 2 0 "///&nbsp;&nbsp;$($txt)&nbsp;&nbsp;\\\"
 		}
 
-		Write-Verbose "$(Get-Date): `t`tGathering user misc data"
+		Write-Verbose "$(Get-Date -Format G): `t`tGathering user misc data"
 		
 		getDSUsers $Domain
 
@@ -15605,7 +15644,7 @@ Function OutputUserInfo
 		[String] $title
 	)
 	
-	Write-Verbose "$(Get-Date): `t`t`t`tOutput $($title)"
+	Write-Verbose "$(Get-Date -Format G): `t`t`t`tOutput $($title)"
 	$Users = $Users | Sort-Object samAccountName
 	
 	If($MSWORD -or $PDF)
@@ -15704,7 +15743,7 @@ Function OutputHDUserInfo
 		[string] $title
 	)
 	
-	Write-Verbose "$(Get-Date): `t`t`t`tOutput $($title)"
+	Write-Verbose "$(Get-Date -Format G): `t`t`t`tOutput $($title)"
 	$Users = $Users | Sort-Object samAccountName
 	
 	If($MSWORD -or $PDF)
@@ -15823,7 +15862,7 @@ Function OutputPGUserInfo
 		[string] $title
 	)
 	
-	Write-Verbose "$(Get-Date): `t`t`t`tOutput $($title)"
+	Write-Verbose "$(Get-Date -Format G): `t`t`t`tOutput $($title)"
 	$Users = $Users | Sort-Object samAccountName
 	
 	If($MSWORD -or $PDF)
@@ -15927,7 +15966,7 @@ Function OutputRDSHDUserInfo
 		[string] $title
 	)
 
-	Write-Verbose "$(Get-Date): `t`t`t`tOutput $($title)"
+	Write-Verbose "$(Get-Date -Format G): `t`t`t`tOutput $($title)"
 	$Users = $Users | Sort-Object samAccountName
 	
 	If( $Users -and $Users.Length -gt 0 )
@@ -16077,8 +16116,8 @@ Function ProcessDCDNSInfo
 		Return
 	}
 	## Domain Controller DNS IP Configuration
-	Write-Verbose "$(Get-Date): Create Domain Controller DNS IP Configuration"
-	Write-Verbose "$(Get-Date): `tAdd Domain Controller DNS IP Configuration table to doc"
+	Write-Verbose "$(Get-Date -Format G): Create Domain Controller DNS IP Configuration"
+	Write-Verbose "$(Get-Date -Format G): `tAdd Domain Controller DNS IP Configuration table to doc"
 	
 	## sort by site then by DC
 	$xDCDNSIPInfo = @( $Script:DCDNSIPInfo | Sort-Object DCSite, DCName )
@@ -16201,8 +16240,8 @@ Function ProcessDCDNSInfo
 		$columnHeaders = $null
 	}
 
-	Write-Verbose "$(Get-Date): Finished Create Domain Controller DNS IP Configuration"
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): Finished Create Domain Controller DNS IP Configuration"
+	Write-Verbose "$(Get-Date -Format G): "
 } ## end Function ProcessDCDNSInfo
 #endregion
 
@@ -16246,8 +16285,8 @@ Function ProcessTimeServerInfo
 		Return
 	}
 	
-	Write-Verbose "$(Get-Date): Create Domain Controller Time Server Configuration"
-	Write-Verbose "$(Get-Date): `tAdd Domain Controller Time Server Configuration table to doc"
+	Write-Verbose "$(Get-Date -Format G): Create Domain Controller Time Server Configuration"
+	Write-Verbose "$(Get-Date -Format G): `tAdd Domain Controller Time Server Configuration table to doc"
 	
 	#sort by DC
 	$xTimeServerInfo = $Script:TimeServerInfo | Sort-Object DCName
@@ -16306,14 +16345,14 @@ Function ProcessTimeServerInfo
 		ForEach( $Item in $xTimeServerInfo )
 		{
 			Line 1 "DC Name`t`t`t: "            $Item.DCName
-			Line 1 "Time source`t`t: "          $Item.TimeSource
-			Line 1 "Announce flags`t`t: "       $Item.AnnounceFlags
-			Line 1 "Max Neg Phase Correction: " $Item.MaxNegPhaseCorrection
-			Line 1 "Max Pos Phase Correction: " $Item.MaxPosPhaseCorrection
-			Line 1 "NTP Server`t`t: "           $Item.NtpServer
-			Line 1 "Type`t`t`t: "               $Item.NtpType
-			Line 1 "Special Poll Interval`t: "  $Item.SpecialPollInterval
-			Line 1 "VMIC Time Provider`t: "     $Item.VMICTimeProvider
+			Line 2 "Time source`t`t: "          $Item.TimeSource
+			Line 2 "Announce flags`t`t: "       $Item.AnnounceFlags
+			Line 2 "Max Neg Phase Correction: " $Item.MaxNegPhaseCorrection
+			Line 2 "Max Pos Phase Correction: " $Item.MaxPosPhaseCorrection
+			Line 2 "NTP Server`t`t: "           $Item.NtpServer
+			Line 2 "Type`t`t`t: "               $Item.NtpType
+			Line 2 "Special Poll Interval`t: "  $Item.SpecialPollInterval
+			Line 2 "VMIC Time Provider`t: "     $Item.VMICTimeProvider
 			Line 0 ''
 		}
 	}
@@ -16367,8 +16406,8 @@ Function ProcessTimeServerInfo
 		WriteHTMLLine 0 0 ''
 	}
 
-	Write-Verbose "$(Get-Date): Finished Create Domain Controller Time Server Configuration"
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): Finished Create Domain Controller Time Server Configuration"
+	Write-Verbose "$(Get-Date -Format G): "
 }
 #endregion
 
@@ -16412,8 +16451,8 @@ Function ProcessEventLogInfo
 		Return
 	}
 	
-	Write-Verbose "$(Get-Date): Create Domain Controller Event Log Data"
-	Write-Verbose "$(Get-Date): `tAdd Domain Controller Event Log Data table to doc"
+	Write-Verbose "$(Get-Date -Format G): Create Domain Controller Event Log Data"
+	Write-Verbose "$(Get-Date -Format G): `tAdd Domain Controller Event Log Data table to doc"
 	
 	#sort by DC and then event log name
 	$xEventLogInfo = @($Script:DCEventLogInfo | Sort-Object EventLogName, DCName)
@@ -16504,8 +16543,8 @@ Function ProcessEventLogInfo
 		WriteHTMLLine 0 0 ''
 	}
 
-	Write-Verbose "$(Get-Date): Finished Create Domain Controller Event Log Data"
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): Finished Create Domain Controller Event Log Data"
+	Write-Verbose "$(Get-Date -Format G): "
 }
 #endregion
 
@@ -16531,7 +16570,7 @@ Function ProcessDocumentOutput
 	{
 		If(Test-Path "$($Script:WordFileName)")
 		{
-			Write-Verbose "$(Get-Date): $($Script:WordFileName) is ready for use"
+			Write-Verbose "$(Get-Date -Format G): $($Script:WordFileName) is ready for use"
 			$GotFile = $True
 		}
 		Else
@@ -16544,7 +16583,7 @@ Function ProcessDocumentOutput
 	{
 		If(Test-Path "$($Script:PDFFileName)")
 		{
-			Write-Verbose "$(Get-Date): $($Script:PDFFileName) is ready for use"
+			Write-Verbose "$(Get-Date -Format G): $($Script:PDFFileName) is ready for use"
 			$GotFile = $True
 		}
 		Else
@@ -16557,7 +16596,7 @@ Function ProcessDocumentOutput
 	{
 		If(Test-Path "$($Script:TextFileName)")
 		{
-			Write-Verbose "$(Get-Date): $($Script:TextFileName) is ready for use"
+			Write-Verbose "$(Get-Date -Format G): $($Script:TextFileName) is ready for use"
 			$GotFile = $True
 		}
 		Else
@@ -16570,7 +16609,7 @@ Function ProcessDocumentOutput
 	{
 		If(Test-Path "$($Script:HTMLFileName)")
 		{
-			Write-Verbose "$(Get-Date): $($Script:HTMLFileName) is ready for use"
+			Write-Verbose "$(Get-Date -Format G): $($Script:HTMLFileName) is ready for use"
 			$GotFile = $True
 		}
 		Else
@@ -16615,11 +16654,11 @@ Function ProcessScriptStart
 #region script end
 Function ProcessScriptEnd
 {
-	Write-Verbose "$(Get-Date): Script has completed"
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): Script has completed"
+	Write-Verbose "$(Get-Date -Format G): "
 
-	Write-Verbose "$(Get-Date): Script started: $($Script:StartTime)"
-	Write-Verbose "$(Get-Date): Script ended: $(Get-Date)"
+	Write-Verbose "$(Get-Date -Format G): Script started: $($Script:StartTime)"
+	Write-Verbose "$(Get-Date -Format G): Script ended: $(Get-Date)"
 	$runtime = $(Get-Date) - $Script:StartTime
 	$Str = [string]::format("{0} days, {1} hours, {2} minutes, {3}.{4} seconds",
 		$runtime.Days,
@@ -16627,7 +16666,7 @@ Function ProcessScriptEnd
 		$runtime.Minutes,
 		$runtime.Seconds,
 		$runtime.Milliseconds)
-	Write-Verbose "$(Get-Date): Elapsed time: $($Str)"
+	Write-Verbose "$(Get-Date -Format G): Elapsed time: $($Str)"
 
 	If($Dev)
 	{
@@ -16729,11 +16768,11 @@ Function ProcessScriptEnd
 			try 
 			{
 				Stop-Transcript | Out-Null
-				Write-Verbose "$(Get-Date): $Script:LogPath is ready for use"
+				Write-Verbose "$(Get-Date -Format G): $Script:LogPath is ready for use"
 			} 
 			catch 
 			{
-				Write-Verbose "$(Get-Date): Transcript/log stop failed"
+				Write-Verbose "$(Get-Date -Format G): Transcript/log stop failed"
 			}
 		}
 	}
@@ -16750,9 +16789,9 @@ Function ProcessGCCollect
 		[String] $tag
 	)
 
-	#Write-Verbose "$(Get-Date): Begin [GC]::Collect, tag = '$tag'"
+	#Write-Verbose "$(Get-Date -Format G): Begin [GC]::Collect, tag = '$tag'"
 	[System.GC]::Collect()
-	#Write-Verbose "$(Get-Date): End [GC]::Collect"
+	#Write-Verbose "$(Get-Date -Format G): End [GC]::Collect"
 }
 #endregion
 
@@ -16844,7 +16883,7 @@ If(($Section -eq "All" -or $Section -eq "Domains"))
 #endregion
 
 #region finish script
-Write-Verbose "$(Get-Date): Finishing up document"
+Write-Verbose "$(Get-Date -Format G): Finishing up document"
 #end of document processing
 
 If(($MSWORD -or $PDF) -and ($Script:CoverPagesExist))

--- a/ADDS_Inventory_V3_ReadMe.rtf
+++ b/ADDS_Inventory_V3_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -88,14 +88,15 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 {\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1818835589\listoverridecount9{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}
 {\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat
 \levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid407474\rsid412309\rsid667579\rsid741398\rsid854968\rsid880017\rsid1520287\rsid1529376\rsid2638156\rsid2710199\rsid2974686
-\rsid3342358\rsid3477011\rsid3828116\rsid3830441\rsid4281248\rsid4467197\rsid4483701\rsid4945864\rsid5720771\rsid5767175\rsid5849890\rsid5904556\rsid6038932\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7681868\rsid7695940\rsid8013811\rsid8793422
-\rsid9243658\rsid9252303\rsid9512169\rsid9727541\rsid9838801\rsid9848053\rsid10101060\rsid10290913\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11433897\rsid11488686\rsid11602030\rsid12197314\rsid12322737\rsid12343757\rsid12588820
-\rsid12675704\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13511313\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14176547\rsid14566444\rsid14697282\rsid14893653\rsid15166704\rsid15355254\rsid16005803\rsid16010693
-\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo10\dy12\hr7}{\version53}
-{\edmins592}{\nofpages23}{\nofwords6822}{\nofchars38888}{\nofcharsws45619}{\vern9}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid3342358\rsid3477011\rsid3828116\rsid3830441\rsid4281248\rsid4467197\rsid4483701\rsid4945864\rsid5315553\rsid5720771\rsid5767175\rsid5849890\rsid5904556\rsid6038932\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7681868\rsid7695940\rsid8013811
+\rsid8220290\rsid8793422\rsid9243658\rsid9252303\rsid9512169\rsid9727541\rsid9838801\rsid9848053\rsid10101060\rsid10290913\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11433897\rsid11488686\rsid11602030\rsid12197314\rsid12322737
+\rsid12343757\rsid12588820\rsid12675704\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13511313\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14176547\rsid14566444\rsid14697282\rsid14893653\rsid15166704\rsid15355254
+\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}
+{\revtim\yr2021\mo1\dy9\hr9\min46}{\version55}{\edmins600}{\nofpages23}{\nofwords6843}{\nofchars39007}{\nofcharsws45759}{\vern15}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAymwrAUAKF+UAywAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwNKgFAFm+xIItAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -105,8 +106,6 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid5767175 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f31506\insrsid5767175\charrsid667579 \hich\af31506\dbch\af31505\loch\f31506 NOTE: This script requires PowerShell V3 or later.
 
-\par \hich\af31506\dbch\af31505\loch\f31506 NOTE: Word 2007 is no}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f31506\insrsid12588820 \hich\af31506\dbch\af31505\loch\f31506 t}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f31506\insrsid5767175\charrsid667579 
-\hich\af31506\dbch\af31505\loch\f31506  supported.}{\rtlch\fcs1 \af37 \ltrch\fcs0 \f31506\insrsid5767175\charrsid667579 
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11433897 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11433897\charrsid11433897 \hich\af37\dbch\af31505\loch\f37 With the Version 3.00 script, you ca
 \hich\af37\dbch\af31505\loch\f37 n now select multiple output formats. You are no longer limited to one output format per script run.
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -271,31 +270,30 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 At least one Windows 7 SP1 or later computer with the Remote Server Administration Tools (RSAT) installed.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid11602030\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 RSAT for Windows 7 SP1 is available here,}{\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 
- HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=7887" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9200000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d0037003800380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000006301000000000000080963000000040000000000000000650000ff00006000000e2d0037ff2d0033}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid11602030 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 R\hich\af37\dbch\af31505\loch\f37 SAT for Windows 8 is available here, }
-{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
-{\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000560000000000004200000000000b00000000002d00000000000041d0146d0e000057006f00015bf8}}}{\fldrslt {\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 
+HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24\hich\af37\dbch\af31505\loch\f37 "}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100630065003500
+65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 R\hich\af37\dbch\af31505\loch\f37 SAT for Windows 8 is available here, }
+{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid5315553 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab00006449000000000000000017000000000000240000000000000000002200003a64006d00000031000000000000}}}{\fldrslt {\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37   
+\ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
+\hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid13858952\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37 RSAT for Windows 10 is available here, }
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12916989 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c00000065000000030200}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c0000006500000003020006}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid13858952 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952\charrsid13858952 
 
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
@@ -366,43 +364,44 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid10945524 \hich\af43\dbch\af31505\loch\f43 Help Text
 \par }\pard\plain \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10945524 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
 \ltrch\fcs0 \insrsid10945524 
-\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid12588820 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \\\hich\af2\dbch\af31505\loch\f2 
-ADDS_Inventory_V3.ps1
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 PS C:\\webster> get-help .\\
+ADDS_Inventory_V3.ps1 -full
+\par 
+\par \hich\af2\dbch\af31505\loch\f2 NAME
+\par \hich\af2\dbch\af31505\loch\f2     C:\\webster\\ADDS_Inventory_V3.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
 \par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft Active Directory Forest.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \\\hich\af2\dbch\af31505\loch\f2 
-ADDS_Inventory_V3.ps1 [-HTML] [-MSWord] [-PDF] [-Text] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 [-ADDomain <String>] [-ADForest <String>] [-CompanyAddress <String>] [-CompanyEmail }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-CoverPage <String>] [-DCDNSInfo] [-Dev] [-Folder <String>] }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 [-From <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 \hich\af2\dbch\af31505\loch\f2  
-}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 [-GPOInheritance] [-Hardware] [-IncludeUserInfo] [-Log] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2     [}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 -MaxDetails] [-ScriptInfo] [-Section <String[]>] [-Services] [-SmtpPort <Int32>] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 [-SmtpServer <String>] [-SuperVerbose] [-To <String>] [-UserName <String>] [-UseSSL] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\webster\\ADDS_Inventory_V3.ps1 [-ADDomain <String>] [-ADForest <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-MaxDetails] [-HTML] [-Text] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 <String>] [-Log] [-ScriptInfo] [-DCDNSInfo] [-GPOInheritance] [-Hardware] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-IncludeUserInfo\hich\af2\dbch\af31505\loch\f2 ] [-Section <String[]>] [-Services] [-MSWord] [-PDF] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 <String>] [-SmtpPort <Int32>] [-SmtpServer\hich\af2\dbch\af31505\loch\f2 
+ <String>] [-SuperVerbose] [-From <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-To <String>] [-UseSSL] [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a M\hich\af2\dbch\af31505\loch\f2 icrosoft Active Directory Forest using Microsoft
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft Active Directory Forest using Microsoft
 \par \hich\af2\dbch\af31505\loch\f2     PowerShell, Word, plain text, or HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Word or PDF document, text, or HTML file named after the Active Directory
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Word o\hich\af2\dbch\af31505\loch\f2 r PDF document, text, or HTML file named after the Active Directory
 \par \hich\af2\dbch\af31505\loch\f2     Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Version 3.0 changes the default output report from Word to\hich\af2\dbch\af31505\loch\f2  HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Version 3.0 changes the default output report from Word to HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF document includes a Cover Page, Table of Contents and Footer.
-\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
+\par \hich\af2\dbch\af31505\loch\f2     Includes support for t\hich\af2\dbch\af31505\loch\f2 he following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
 \par \hich\af2\dbch\af31505\loch\f2         Danish
@@ -418,135 +417,65 @@ ADDS_Inventory_V3.ps1 [-HTML] [-MSWord] [-PDF] [-Text] [-AddDateTime] }{\rtlch\f
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script requires at least PowerShell version 3 but runs best in version 5.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script wil\hich\af2\dbch\af31505\loch\f2 l output in Text and HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script will output in Text and HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a domain controller. This script was developed
+\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a domain controller. This scr\hich\af2\dbch\af31505\loch\f2 ipt was developed
 \par \hich\af2\dbch\af31505\loch\f2     and run from a Windows 10 VM.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     While most of the script can be run with a non-admin account, there are some features
-\par \hich\af2\dbch\af31505\loch\f2     that will \hich\af2\dbch\af31505\loch\f2 not or may not work without domain admin or enterprise admin rights.
-\par \hich\af2\dbch\af31505\loch\f2     The Hardware and Services parameters require domain admin privileges.
+\par \hich\af2\dbch\af31505\loch\f2     that will not or may not work without domain admin or enterprise admin rights.
+\par \hich\af2\dbch\af31505\loch\f2     The Hardware and Services \hich\af2\dbch\af31505\loch\f2 parameters require domain admin privileges.
 \par 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 
-The script does gathering of information on Time Server and AD database, log file, and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 SYSVOL locations\hich\af2\dbch\af31505\loch\f2 
-. Those require access to the registry on each domain controller, which }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 means the script should now always be run from an elevated PowerShell session with an }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 account with a minimum of domain admin rights.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 
-
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 
+\par \hich\af2\dbch\af31505\loch\f2     The script does gathering of information on Time Server and AD database, log file, and
+\par \hich\af2\dbch\af31505\loch\f2     SYSVOL locations. Those require access to the registry on each domain controller, which
+\par \hich\af2\dbch\af31505\loch\f2     means the script should \hich\af2\dbch\af31505\loch\f2 now always be run from an elevated PowerShell session with an
+\par \hich\af2\dbch\af31505\loch\f2     account with a minimum of domain admin rights.
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     Running the script in a forest with multiple domains requires Enterprise Admin rights.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The count of all users may not be accurate if the user running the script does not have
+\par \hich\af2\dbch\af31505\loch\f2     The count of all users may not be accurate if \hich\af2\dbch\af31505\loch\f2 the user running the script does not have
 \par \hich\af2\dbch\af31505\loch\f2     the necessary permissions on all user objects.  In that case, there may be user accounts
 \par \hich\af2\dbch\af31505\loch\f2     classified as "unknown".
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To run the script from a workstation, RSAT is required.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 7 with Service Pack 1\hich\af2\dbch\af31505\loch\f2  (SP1)
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=7887" }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid12588820 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9200000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d0037003800380037000000795881f43b1d7f48af2c825dc485276300000000a5ab00033e70}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12588820\charrsid12588820 
-\hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/dow\hich\af2\dbch\af31505\loch\f2 nload/details.aspx?id=7887}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100630065003500
+65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid12588820 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab00036566}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12588820\charrsid12588820 
-\hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=28972}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tool\hich\af2\dbch\af31505\loch\f2 s for Windows 8
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://c\hich\af2\dbch\af31505\loch\f2 
+arlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8.1
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296" }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid12588820 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab00036900}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12588820\charrsid12588820 
-\hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=39296}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://carlwebster.sharefile.com/d-s37
+\hich\af2\dbch\af31505\loch\f2 209afb73dc48f497745924ed854226"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 10
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
-HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administr\hich\af2\dbch\af31505\loch\f2 ation Tools for Windows 10
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK \hich\af2\dbch\af31505\loch\f2 
+"http://www.microsoft.com/en-us/download/details.aspx?id=45520"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab00032000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12588820\charrsid12588820 
-\hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.a\hich\af2\dbch\af31505\loch\f2 spx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
-\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         HTML is now the default report format.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?  \hich\af2\dbch\af31505\loch\f2                   false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Microsoft Word is no longer the default report format.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger th\hich\af2\dbch\af31505\loch\f2 an the DOCX file.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter uses Word's SaveAs PDF capability.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?      \hich\af2\dbch\af31505\loch\f2               named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pi\hich\af2\dbch\af31505\loch\f2 peline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds a date timestamp to the end of the file name.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         The timestamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2         June 1, 2020 at 6PM is\hich\af2\dbch\af31505\loch\f2  2020-06-01_1800.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2020-06-01_1800.docx (or .pdf).
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?         \hich\af2\dbch\af31505\loch\f2            named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -ADDomain <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory domain object by providing one of the following
-\par \hich\af2\dbch\af31505\loch\f2         property values. The identifier in parentheses is the LDAP display name for the
-\par \hich\af2\dbch\af31505\loch\f2         attribute. All values are for the domainDNS object that represents the dom\hich\af2\dbch\af31505\loch\f2 ain.
+\par \hich\af2\dbch\af31505\loch\f2         property values. The identifi\hich\af2\dbch\af31505\loch\f2 er in parentheses is the LDAP display name for the
+\par \hich\af2\dbch\af31505\loch\f2         attribute. All values are for the domainDNS object that represents the domain.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Distinguished Name
 \par 
@@ -554,11 +483,11 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         GUID (objectGUID)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Example: b9fa5fbd-4334-4a98-85f1-3a3a44069fc6
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Example: b9fa5fbd-4334-4a98-85f1-3a3a44069fc6
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Security Identifier (objectSid)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Example: S-1-5-21-3643273344-1\hich\af2\dbch\af31505\loch\f2 505409314-3732760578
+\par \hich\af2\dbch\af31505\loch\f2         Example: S-1-5-21-3643273344-1505409314-3732760578
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         DNS domain name
 \par 
@@ -570,19 +499,19 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If both ADForest and ADDomain are specified, ADDomain takes precedence.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?     \hich\af2\dbch\af31505\loch\f2                false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?         \hich\af2\dbch\af31505\loch\f2            named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ADForest <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory forest object by providing one of the following
-\par \hich\af2\dbch\af31505\loch\f2         attribute values.
+\par \hich\af2\dbch\af31505\loch\f2         attribute val\hich\af2\dbch\af31505\loch\f2 ues.
 \par \hich\af2\dbch\af31505\loch\f2         The identifier in parentheses is the LDAP display name for the attribute.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Fully qualified domain name
-\par \hich\af2\dbch\af31505\loch\f2                 Example: \hich\af2\dbch\af31505\loch\f2 labaddomain.com
+\par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2         GUID (objectGUID)
 \par \hich\af2\dbch\af31505\loch\f2                 Example: 599c3d2e-e61e-4d20-7b77-030d99495e19
 \par \hich\af2\dbch\af31505\loch\f2         DNS host name
@@ -590,46 +519,315 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par \hich\af2\dbch\af31505\loch\f2         NetBIOS name
 \par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Default value is $Env:\hich\af2\dbch\af31505\loch\f2 USERDNSDOMAIN
+\par \hich\af2\dbch\af31505\loch\f2         Default value is $Env:USERDNSDOMAIN
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         If both ADForest and ADDomain are specified, ADDomain takes precedence.
+\par \hich\af2\dbch\af31505\loch\f2         If both ADForest an\hich\af2\dbch\af31505\loch\f2 d ADDomain are specified, ADDomain takes precedence.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:USERDNSDOMAIN
-\par \hich\af2\dbch\af31505\loch\f2         Accept pip\hich\af2\dbch\af31505\loch\f2 eline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wi\hich\af2\dbch\af31505\loch\f2 ldcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -ComputerName <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies which domain controller to use to run the script against.
+\par \hich\af2\dbch\af31505\loch\f2         If ADForest is a trusted forest, then ComputerName is required to detect the
+\par \hich\af2\dbch\af31505\loch\f2         existence of ADForest.
+\par \hich\af2\dbch\af31505\loch\f2         Co\hich\af2\dbch\af31505\loch\f2 mputerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
+\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and used.
+\par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and use the actual
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 computer name.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ServerName.
+\par \hich\af2\dbch\af31505\loch\f2         Default value is $Env:USERDNSDOMAIN
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:USERDNSDOMAIN
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -MaxDetails [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Adds maximum detail to the report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This is the same as using\hich\af2\dbch\af31505\loch\f2  the following parameters:
+\par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo
+\par \hich\af2\dbch\af31505\loch\f2                 GPOInheritance
+\par \hich\af2\dbch\af31505\loch\f2                 Hardware
+\par \hich\af2\dbch\af31505\loch\f2                 IncludeUserInfo
+\par \hich\af2\dbch\af31505\loch\f2                 Services
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extremely large report and
+\par \hich\af2\dbch\af31505\loch\f2         ca\hich\af2\dbch\af31505\loch\f2 n take a very long time to run.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         HTML is now the default report format.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    n\hich\af2\dbch\af31505\loch\f2 amed
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Adds a date timestamp to the end of the file name.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         The timestamp is\hich\af2\dbch\af31505\loch\f2  in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2         June 1, 2021 at 6PM is 2021-06-01_1800.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2021-06-01_1800.docx (or .pdf).
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fa\hich\af2\dbch\af31505\loch\f2 lse
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         The text\hich\af2\dbch\af31505\loch\f2  file is placed in the same folder from where the script is run.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accep\hich\af2\dbch\af31505\loch\f2 t pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?       \hich\af2\dbch\af31505\loch\f2              named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
+\par \hich\af2\dbch\af31505\loch\f2         Th\hich\af2\dbch\af31505\loch\f2 e text file is placed in the same folder from where the script is run.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -DCDNSInfo [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather, for each domain controller, the IP Address, and each DNS server
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  configured.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain
+\par \hich\af2\dbch\af31505\loch\f2         Admin).
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add an extra section to the report.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?              \hich\af2\dbch\af31505\loch\f2       false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -GPOInheritance [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         In the Group Policies b\hich\af2\dbch\af31505\loch\f2 y OU section, adds Inherited GPOs in addition to the GPOs
+\par \hich\af2\dbch\af31505\loch\f2         directly linked.
+\par \hich\af2\dbch\af31505\loch\f2         Adds a second column to the table GPO Type.
+\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by d\hich\af2\dbch\af31505\loch\f2 efault.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of GPO.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard charact\hich\af2\dbch\af31505\loch\f2 ers?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor, and
+\par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain
+\par \hich\af2\dbch\af31505\loch\f2         Admin).
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes\hich\af2\dbch\af31505\loch\f2  to run the script and
+\par \hich\af2\dbch\af31505\loch\f2         size of the report.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inpu\hich\af2\dbch\af31505\loch\f2 t?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -IncludeUserInfo [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         For the User Miscellaneous Data section outputs a table with the SamAccountName
+\par \hich\af2\dbch\af31505\loch\f2         and DistinguishedName of the users in the All Users counts:
+\par 
+\par \hich\af2\dbch\af31505\loch\f2                 Disabled users
+\par \hich\af2\dbch\af31505\loch\f2                 Unknown users
+\par \hich\af2\dbch\af31505\loch\f2                 Locked out users
+\par \hich\af2\dbch\af31505\loch\f2                 All users with password expired
+\par \hich\af2\dbch\af31505\loch\f2                 All users whose password never expires
+\par \hich\af2\dbch\af31505\loch\f2                 All users with password not required
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2            All users who cannot change password
+\par \hich\af2\dbch\af31505\loch\f2                 All users with SID History
+\par \hich\af2\dbch\af31505\loch\f2                 All users with Homedrive set in ADUC
+\par \hich\af2\dbch\af31505\loch\f2                 All users whose Primary Group is not Domain Users
+\par \hich\af2\dbch\af31505\loch\f2                 All users with RDS HomeDrive s\hich\af2\dbch\af31505\loch\f2 et in ADUC
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         The Text output option is limited to the first 25 characters of the SamAccountName
+\par \hich\af2\dbch\af31505\loch\f2         and the first 116 characters of the DistinguishedName.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of IU.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?      \hich\af2\dbch\af31505\loch\f2  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Section <String[]>
+\par \hich\af2\dbch\af31505\loch\f2         Processes one or more sections of the report.
+\par \hich\af2\dbch\af31505\loch\f2         Valid options are:
+\par \hich\af2\dbch\af31505\loch\f2                 Forest
+\par \hich\af2\dbch\af31505\loch\f2                 Sites
+\par \hich\af2\dbch\af31505\loch\f2                 Domains (includes Domain Controllers an\hich\af2\dbch\af31505\loch\f2 d optional Hardware, Services and
+\par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo)
+\par \hich\af2\dbch\af31505\loch\f2                 OUs (Organizational Units)
+\par \hich\af2\dbch\af31505\loch\f2                 Groups
+\par \hich\af2\dbch\af31505\loch\f2                 GPOs
+\par \hich\af2\dbch\af31505\loch\f2                 Misc (Miscellaneous data)
+\par \hich\af2\dbch\af31505\loch\f2                 All
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to All sectio\hich\af2\dbch\af31505\loch\f2 ns.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Multiple sections are separated by a comma. -Section forest, domains
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                All
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Services [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Gather information on all services running on domain controllers.
+\par \hich\af2\dbch\af31505\loch\f2         Servers that are configured to automatically start bu\hich\af2\dbch\af31505\loch\f2 t are not running will be
+\par \hich\af2\dbch\af31505\loch\f2         colored in red.
+\par \hich\af2\dbch\af31505\loch\f2         Used on Domain Controllers only.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve service information (i.e. \hich\af2\dbch\af31505\loch\f2 Domain
+\par \hich\af2\dbch\af31505\loch\f2         Admin).
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
+\par \hich\af2\dbch\af31505\loch\f2         size of the report.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?       \hich\af2\dbch\af31505\loch\f2              named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Microsoft Word is no longer the default r\hich\af2\dbch\af31505\loch\f2 eport format.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter \hich\af2\dbch\af31505\loch\f2 requires Microsoft Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter uses Word's SaveAs PDF capability.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value \hich\af2\dbch\af31505\loch\f2                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cove\hich\af2\dbch\af31505\loch\f2 r Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Wor\hich\af2\dbch\af31505\loch\f2 d 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/201\hich\af2\dbch\af31505\loch\f2 6)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the \hich\af2\dbch\af31505\loch\f2 MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipel\hich\af2\dbch\af31505\loch\f2 ine input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard cha\hich\af2\dbch\af31505\loch\f2 racters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
-\par \hich\af2\dbch\af31505\loch\f2                 Fa\hich\af2\dbch\af31505\loch\f2 cet (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is on\hich\af2\dbch\af31505\loch\f2 ly valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -639,317 +837,118 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax fi\hich\af2\dbch\af31505\loch\f2 eld.
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2          Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?    \hich\af2\dbch\af31505\loch\f2                 named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for th\hich\af2\dbch\af31505\loch\f2 e Cover Page.
+\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         Default value is contained in
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
 \par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
-\par \hich\af2\dbch\af31505\loch\f2         If either registry key does not exist and this parameter is not specified, the report
+\par \hich\af2\dbch\af31505\loch\f2         If either regis\hich\af2\dbch\af31505\loch\f2 try key does not exist and this parameter is not specified, the report
 \par \hich\af2\dbch\af31505\loch\f2         will not contain a Company Name on the cover page.
-\par \hich\af2\dbch\af31505\loch\f2         This par\hich\af2\dbch\af31505\loch\f2 ameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fal\hich\af2\dbch\af31505\loch\f2 se
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page if the Cover Page has the Phone field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word\hich\af2\dbch\af31505\loch\f2  2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input? \hich\af2\dbch\af31505\loch\f2       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -ComputerName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies which domain controller to use to run the script against.
-\par \hich\af2\dbch\af31505\loch\f2         If ADForest is a trusted forest, then ComputerName is required to detect the
-\par \hich\af2\dbch\af31505\loch\f2         existence of ADForest.
-\par \hich\af2\dbch\af31505\loch\f2         ComputerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
-\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer\hich\af2\dbch\af31505\loch\f2  name is determined and used.
-\par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and use the actual
-\par \hich\af2\dbch\af31505\loch\f2         computer name.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ServerName.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is $Env:USERDNSDOMAIN
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required? \hich\af2\dbch\af31505\loch\f2                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:USERDNSDOMAIN
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept \hich\af2\dbch\af31505\loch\f2 pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
-\par \hich\af2\dbch\af31505\loch\f2         What Microsof\hich\af2\dbch\af31505\loch\f2 t Word Cover Page to use.
+\par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
 \par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this re\hich\af2\dbch\af31505\loch\f2 port)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
+\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, \hich\af2\dbch\af31505\loch\f2 mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
 \par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast \hich\af2\dbch\af31505\loch\f2 (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Wo\hich\af2\dbch\af31505\loch\f2 rd 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Grid (Wor\hich\af2\dbch\af31505\loch\f2 d 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2          \hich\af2\dbch\af31505\loch\f2        Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or fon\hich\af2\dbch\af31505\loch\f2 t changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Wo\hich\af2\dbch\af31505\loch\f2 rd 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
-\par \hich\af2\dbch\af31505\loch\f2                 36 point)
+\par \hich\af2\dbch\af31505\loch\f2                 36\hich\af2\dbch\af31505\loch\f2  point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
-\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Perspective (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
-\par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/20\hich\af2\dbch\af31505\loch\f2 16. Works)
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2               resized or font changed to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Ligh\hich\af2\dbch\af31505\loch\f2 t) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Wor\hich\af2\dbch\af31505\loch\f2 d 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
+\par \hich\af2\dbch\af31505\loch\f2         The default\hich\af2\dbch\af31505\loch\f2  value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output paramete\hich\af2\dbch\af31505\loch\f2 rs.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
+\par \hich\af2\dbch\af31505\loch\f2         Default value     \hich\af2\dbch\af31505\loch\f2            Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -DCDNSInfo [<SwitchParameter\hich\af2\dbch\af31505\loch\f2 >]
-\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather, for each domain controller, the IP Address, and each DNS server
-\par \hich\af2\dbch\af31505\loch\f2         configured.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve har\hich\af2\dbch\af31505\loch\f2 dware information (i.e. Domain
-\par \hich\af2\dbch\af31505\loch\f2         Admin).
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add an extra section to the report.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
+\par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
+\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
+\par \hich\af2\dbch\af31505\loch\f2         This parame\hich\af2\dbch\af31505\loch\f2 ter has an alias of UN.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
-\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
-\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder\hich\af2\dbch\af31505\loch\f2  from where the script is run.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept\hich\af2\dbch\af31505\loch\f2  pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -From <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or To are used, this is a required parameter.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -GPOInheritance [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         In the Group \hich\af2\dbch\af31505\loch\f2 Policies by OU section, adds Inherited GPOs in addition to the GPOs
-\par \hich\af2\dbch\af31505\loch\f2         directly linked.
-\par \hich\af2\dbch\af31505\loch\f2         Adds a second column to the table GPO Type.
-\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is dis\hich\af2\dbch\af31505\loch\f2 abled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of GPO.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildca\hich\af2\dbch\af31505\loch\f2 rd characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor, and
-\par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell \hich\af2\dbch\af31505\loch\f2 session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain
-\par \hich\af2\dbch\af31505\loch\f2         Admin).
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
-\par \hich\af2\dbch\af31505\loch\f2         size of the report.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -IncludeUserInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         For the User Miscellaneous Data section outputs a table with the SamAccountName
-\par \hich\af2\dbch\af31505\loch\f2         and DistinguishedName of the users in the All Users counts:
-\par 
-\par \hich\af2\dbch\af31505\loch\f2                 Disabled users
-\par \hich\af2\dbch\af31505\loch\f2                 Unk\hich\af2\dbch\af31505\loch\f2 nown users
-\par \hich\af2\dbch\af31505\loch\f2                 Locked out users
-\par \hich\af2\dbch\af31505\loch\f2                 All users with password expired
-\par \hich\af2\dbch\af31505\loch\f2                 All users whose password never expires
-\par \hich\af2\dbch\af31505\loch\f2                 All users with password not required
-\par \hich\af2\dbch\af31505\loch\f2                 All users who cannot change password
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              All users with SID History
-\par \hich\af2\dbch\af31505\loch\f2                 All users with Homedrive set in ADUC
-\par \hich\af2\dbch\af31505\loch\f2                 All users whose Primary Group is not Domain Users
-\par \hich\af2\dbch\af31505\loch\f2                 All users with RDS HomeDrive set in ADUC
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         The Text output option is limit\hich\af2\dbch\af31505\loch\f2 ed to the first 25 characters of the SamAccountName
-\par \hich\af2\dbch\af31505\loch\f2         and the first 116 characters of the DistinguishedName.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of IU.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gen\hich\af2\dbch\af31505\loch\f2 erates a log file for troubleshooting.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -MaxDetails [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds maximum detail to the report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This is the same as using the following parameters:
-\par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo
-\par \hich\af2\dbch\af31505\loch\f2                 GPOInheritance
-\par \hich\af2\dbch\af31505\loch\f2                 Hardware
-\par \hich\af2\dbch\af31505\loch\f2                 IncludeUserInfo
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2               Services
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extremely large report and
-\par \hich\af2\dbch\af31505\loch\f2         can take a very long time to run.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Outputs information about the script to a text file.
-\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?         \hich\af2\dbch\af31505\loch\f2            false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Section <String[]>
-\par \hich\af2\dbch\af31505\loch\f2         Processes one or more sections of \hich\af2\dbch\af31505\loch\f2 the report.
-\par \hich\af2\dbch\af31505\loch\f2         Valid options are:
-\par \hich\af2\dbch\af31505\loch\f2                 Forest
-\par \hich\af2\dbch\af31505\loch\f2                 Sites
-\par \hich\af2\dbch\af31505\loch\f2                 Domains (includes Domain Controllers and optional Hardware, Services and
-\par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo)
-\par \hich\af2\dbch\af31505\loch\f2                 OUs (Organizational Units)
-\par \hich\af2\dbch\af31505\loch\f2                 Groups
-\par \hich\af2\dbch\af31505\loch\f2                 GPOs
-\par \hich\af2\dbch\af31505\loch\f2                 Misc (Miscellaneous data)
-\par \hich\af2\dbch\af31505\loch\f2                 All
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to All sections.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Multiple sections are separated by a comma. -Sec\hich\af2\dbch\af31505\loch\f2 tion forest, domains
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                All
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Services [<Swit\hich\af2\dbch\af31505\loch\f2 chParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gather information on all services running on domain controllers.
-\par \hich\af2\dbch\af31505\loch\f2         Servers that are configured to automatically start but are not running will be
-\par \hich\af2\dbch\af31505\loch\f2         colored in red.
-\par \hich\af2\dbch\af31505\loch\f2         Used on Domain Controllers only.
-\par \hich\af2\dbch\af31505\loch\f2         This par\hich\af2\dbch\af31505\loch\f2 ameter requires the script be run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve service information (i.e. Domain
-\par \hich\af2\dbch\af31505\loch\f2         Admin).
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the scrip\hich\af2\dbch\af31505\loch\f2 t and
-\par \hich\af2\dbch\af31505\loch\f2         size of the report.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -958,16 +957,16 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?      \hich\af2\dbch\af31505\loch\f2               named
+\par \hich\af2\dbch\af31505\loch\f2         Require\hich\af2\dbch\af31505\loch\f2 d?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report(s).
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional em\hich\af2\dbch\af31505\loch\f2 ail server to send the output report(s).
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         I\hich\af2\dbch\af31505\loch\f2 f From or To are used, this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2         If From or To are used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -975,7 +974,7 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Su\hich\af2\dbch\af31505\loch\f2 perVerbose [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -SuperVerbose [<SwitchParameter>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -983,28 +982,27 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -To <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
+\par \hich\af2\dbch\af31505\loch\f2     -From <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or From are used, this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or To are used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?      \hich\af2\dbch\af31505\loch\f2               named
+\par \hich\af2\dbch\af31505\loch\f2         Required?    \hich\af2\dbch\af31505\loch\f2                 false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:userna\hich\af2\dbch\af31505\loch\f2 me
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2     -To <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  If SmtpServer or From are used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:u\hich\af2\dbch\af31505\loch\f2 sername
+\par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fals\hich\af2\dbch\af31505\loch\f2 e
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
@@ -1017,23 +1015,30 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
-\par \hich\af2\dbch\af31505\loch\f2         This cmdl\hich\af2\dbch\af31505\loch\f2 et supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable,\hich\af2\dbch\af31505\loch\f2  WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.microsoft.com/f\hich\af2\dbch\af31505\loch\f2 wlink/?LinkID=113216).
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
+\par 
+\par \hich\af2\dbch\af31505\loch\f2 OU\hich\af2\dbch\af31505\loch\f2 TPUTS
 \par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a Word or PDF document.
 \par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
+\par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: ADDS_Inventory_V3.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9848053 \hich\af2\dbch\af31505\loch\f2 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2         AUT\hich\af2\dbch\af31505\loch\f2 HOR: Carl Webster and Michael B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9848053 \hich\af2\dbch\af31505\loch\f2 Octob\hich\af2\dbch\af31505\loch\f2 er 12, 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid12588820\charrsid12588820 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.02
+\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and Michael B. Smith
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: January 9, 2021
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -1041,30 +1046,30 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest def\hich\af2\dbch\af31505\loch\f2 aults to the value of $Env:USERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNS\hich\af2\dbch\af31505\loch\f2 DOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 ------------------------- EXAMPLE 2 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -MSWord
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Invent\hich\af2\dbch\af31505\loch\f2 ory_V3.ps1 -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY\hich\af2\dbch\af31505\loch\f2 _CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username \hich\af2\dbch\af31505\loch\f2 = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to \hich\af2\dbch\af31505\loch\f2 the value of $Env:USERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
@@ -1077,45 +1082,46 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Creates an HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for Com\hich\af2\dbch\af31505\loch\f2 puterName.
+\par \hich\af2\dbch\af31505\loch\f2     a domain \hich\af2\dbch\af31505\loch\f2 controller that is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADDomain child.company.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADDomain}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 child.company.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     child.company.tld for the AD Domain.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will us\hich\af2\dbch\af31505\loch\f2 e that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     --\hich\af2\dbch\af31505\loch\f2 ------------------------ EXAMPLE 5 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest parent.company.tld -ADDomain}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2     child.company.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest parent.company.tld -ADDomain
+\par \hich\af2\dbch\af31505\loch\f2     child.company.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Because both ADForest and ADDomain are specified, ADD\hich\af2\dbch\af31505\loch\f2 omain wins and child.company.tld
+\par \hich\af2\dbch\af31505\loch\f2     B\hich\af2\dbch\af31505\loch\f2 ecause both ADForest and ADDomain are specified, ADDomain wins and child.company.tld
 \par \hich\af2\dbch\af31505\loch\f2     is used for AD Domain.
 \par \hich\af2\dbch\af31505\loch\f2     ADForest is set to the value of ADDomain.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog serve\hich\af2\dbch\af31505\loch\f2 r and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     a d\hich\af2\dbch\af31505\loch\f2 omain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par 
@@ -1123,21 +1129,21 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -ADForest company.tld -ComputerName DC01 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 -MSWord
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -ComputerName DC01
+\par \hich\af2\dbch\af31505\loch\f2     -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_C\hich\af2\dbch\af31505\loch\f2 URRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD F\hich\af2\dbch\af31505\loch\f2 orest
+\par \hich\af2\dbch\af31505\loch\f2     co\hich\af2\dbch\af31505\loch\f2 mpany.tld for the AD Forest
 \par \hich\af2\dbch\af31505\loch\f2     The script will be run remotely on the DC01 domain controller.
 \par 
 \par 
@@ -1147,18 +1153,18 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default valu\hich\af2\dbch\af31505\loch\f2 es and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrat\hich\af2\dbch\af31505\loch\f2 or
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, \hich\af2\dbch\af31505\loch\f2 then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
@@ -1167,13 +1173,13 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Text -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.p\hich\af2\dbch\af31505\loch\f2 s1 -Text -ADForest corp.carlwebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a formatted text file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults t\hich\af2\dbch\af31505\loch\f2 o the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
@@ -1205,14 +1211,14 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the v\hich\af2\dbch\af31505\loch\f2 alue of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMP\hich\af2\dbch\af31505\loch\f2 LE 11 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -services
 \par 
@@ -1220,7 +1226,7 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and add additional information for the services running
 \par \hich\af2\dbch\af31505\loch\f2     on each domain controller.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaul\hich\af2\dbch\af31505\loch\f2 ts to the value of $Env:USERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the va\hich\af2\dbch\af31505\loch\f2 lue of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
@@ -1229,19 +1235,19 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----\hich\af2\dbch\af31505\loch\f2 ---------------------- EXAMPLE 12 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------------\hich\af2\dbch\af31505\loch\f2 ---------- EXAMPLE 12 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -DCDNSInfo
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and add additional information for each domain controller
-\par \hich\af2\dbch\af31505\loch\f2     about its DNS IP\hich\af2\dbch\af31505\loch\f2  configuration.
+\par \hich\af2\dbch\af31505\loch\f2     about its DNS IP configuration.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     An extra section will be added to the end of the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     Comp\hich\af2\dbch\af31505\loch\f2 uterName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
@@ -1250,14 +1256,13 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 -CoverPage "Mod" -UserName "Carl Webster" -ComputerName ADDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster
+\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage "Mod" -UserName "Carl Webster" -ComputerName ADDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Web\hich\af2\dbch\af31505\loch\f2 ster Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Con\hich\af2\dbch\af31505\loch\f2 sulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par 
@@ -1268,48 +1273,46 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     --------------\hich\af2\dbch\af31505\loch\f2 ------------ EXAMPLE 14 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CN "Carl Webster Consulting" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 -CP "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 -UN "Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CN "Carl Webster Consulting"
+\par \hich\af2\dbch\af31505\loch\f2     -CP "Mod" -UN "Carl Webster"
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Car\hich\af2\dbch\af31505\loch\f2 l Webster Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $\hich\af2\dbch\af31505\loch\f2 Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of\hich\af2\dbch\af31505\loch\f2  $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ------------------------\hich\af2\dbch\af31505\loch\f2 -- EXAMPLE 15 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PS\hich\af2\dbch\af31505\loch\f2 Script .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid12588820 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2     Street, London, England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2   
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 Street, London, England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Cre\hich\af2\dbch\af31505\loch\f2 ates a Microsoft Word report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes\hich\af2\dbch\af31505\loch\f2  Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for\hich\af2\dbch\af31505\loch\f2  the Company Phone.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the val\hich\af2\dbch\af31505\loch\f2 ue of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
@@ -1318,15 +1321,14 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS \hich\af2\dbch\af31505\loch\f2 C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 -CoverPage Facet -UserName "Dr. Watson" -CompanyEmail }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2 SuperSleuth@SherlockHolmes.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Facet -UserName "Dr. Watson" -CompanyEmail
+\par \hich\af2\dbch\af31505\loch\f2     SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holme\hich\af2\dbch\af31505\loch\f2 s Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
@@ -1334,75 +1336,73 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for Compute\hich\af2\dbch\af31505\loch\f2 rName.
+\par \hich\af2\dbch\af31505\loch\f2     a \hich\af2\dbch\af31505\loch\f2 domain controller that is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -AddDateTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -AddDate\hich\af2\dbch\af31505\loch\f2 Time
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to t\hich\af2\dbch\af31505\loch\f2 he value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in t\hich\af2\dbch\af31505\loch\f2 he format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2020 at 6PM is 2020-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be company.tld_2020-06-01_1800.docx.
+\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 202\hich\af2\dbch\af31505\loch\f2 1-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be company.tld_2021-06-01_1800.docx.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12675704 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid12588820 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2     -AddDateTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     Wil\hich\af2\dbch\af31505\loch\f2 l use all default values and save the document as a PDF file.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_\hich\af2\dbch\af31505\loch\f2 USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env\hich\af2\dbch\af31505\loch\f2 :username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline f\hich\af2\dbch\af31505\loch\f2 or the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog serv\hich\af2\dbch\af31505\loch\f2 er and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file n\hich\af2\dbch\af31505\loch\f2 ame.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2020 at 6PM is 2020-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be corp.carlwebster\hich\af2\dbch\af31505\loch\f2 .com_2020-06-01_1800.PDF
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 2021-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be corp.carlwebster.com_2021-06-01_1800.PDF
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest corp.carlwebster.com -Folder}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12675704 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid12588820 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2     \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest corp.carlwebster.com -Folder
+\par \hich\af2\dbch\af31505\loch\f2     \\\\FileServer\\ShareName
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Creates an HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script q\hich\af2\dbch\af31505\loch\f2 ueries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     val\hich\af2\dbch\af31505\loch\f2 ue for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The output file will be saved in the path \\\\FileServer\\ShareName.
 \par 
@@ -1417,7 +1417,7 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value\hich\af2\dbch\af31505\loch\f2  of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
@@ -1426,23 +1426,22 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- E\hich\af2\dbch\af31505\loch\f2 XAMPLE 21 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Section groups, misc -ADForest
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com -Se\hich\af2\dbch\af31505\loch\f2 rverName PrimaryDC.websterslab.com
+\par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com -ServerName PrimaryDC.websterslab.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com for ADForest.
-\par \hich\af2\dbch\af31505\loch\f2     PrimaryDC.websterslab.com for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     PrimaryDC.webst\hich\af2\dbch\af31505\loch\f2 erslab.com for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The report will include only the Groups and Miscellaneous sections.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- E\hich\af2\dbch\af31505\loch\f2 XAMPLE 22 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -MaxDetails
 \par 
@@ -1453,7 +1452,7 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par \hich\af2\dbch\af31505\loch\f2         GPOInheritance  = True
 \par \hich\af2\dbch\af31505\loch\f2         Hardware        = True
 \par \hich\af2\dbch\af31505\loch\f2         IncludeUserInfo = True
-\par \hich\af2\dbch\af31505\loch\f2         Services        = True
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Services        = True
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Section         = "All"
 \par 
@@ -1462,14 +1461,13 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer \hich\af2\dbch\af31505\loch\f2 mail.domain.tld -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12675704 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2     XDAdmin@domain.tld -To ITGroup@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer mail.domain.tld -From
+\par \hich\af2\dbch\af31505\loch\f2     XDAdmin@domain.tld -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
 \par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will n\hich\af2\dbch\af31505\loch\f2 ot use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
 \par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
@@ -1479,33 +1477,32 @@ HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtl
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -SmtpServer mailrelay.domain.tld -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12675704 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To ITGroup@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer mailrelay.domain.tld -From
+\par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mailrelay.domain.tld, sending from
-\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld, se\hich\af2\dbch\af31505\loch\f2 nding to ITGroup@domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mailrelay.domain.tld, send\hich\af2\dbch\af31505\loch\f2 ing from
+\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld, sending to ITGroup@domain.tld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send unauthenticated email using an email relay server requires the From email account
 \par \hich\af2\dbch\af31505\loch\f2     to use the name Anonymous.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not u\hich\af2\dbch\af31505\loch\f2 se SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RE\hich\af2\dbch\af31505\loch\f2 LAY***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12675704 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid12675704 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/\hich\af2\dbch\af31505\loch\f2 
+a/answer/2956491?hl=en"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00037035}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12588820\charrsid12675704 \hich\af2\dbch\af31505\loch\f2 
-https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12675704 \hich\af2\dbch\af31505\loch\f2  HYP\hich\af2\dbch\af31505\loch\f2 ERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12675704 {\*\datafield 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en"
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003636c}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12588820\charrsid12675704 \hich\af2\dbch\af31505\loch\f2 
-https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send email using a\hich\af2\dbch\af31505\loch\f2  Gmail or g-suite account, you may have to turn ON
+\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
 \par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
@@ -1515,25 +1512,25 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----\hich\af2\dbch\af31505\loch\f2 ---------------------- EXAMPLE 25 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12675704 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
-\par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer
+\par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
+\par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL\hich\af2\dbch\af31505\loch\f2 @labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12675704 \hich\af2\dbch\af31505\loch\f2 
- HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-offi\hich\af2\dbch\af31505\loch\f2 ce-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12675704 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900460075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00034665}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12588820\charrsid12675704 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-u\hich\af2\dbch\af31505\loch\f2 
-s/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3}
+}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
+\par \hich\af2\dbch\af31505\loch\f2     ***OFF\hich\af2\dbch\af31505\loch\f2 ICE 365 Example***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server labaddomain-com.mail.protection.outlook.com,
 \par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
@@ -1543,14 +1540,13 @@ s/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-appl
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----\hich\af2\dbch\af31505\loch\f2 --------------------- EXAMPLE 26 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer smtp.office365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13511313 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid12588820 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADD\hich\af2\dbch\af31505\loch\f2 S_Inventory_V3.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email \hich\af2\dbch\af31505\loch\f2 server smtp.office365.com on port 587 using SSL,
-\par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.\hich\af2\dbch\af31505\loch\f2 com, sending to ITGroup@carlwebster.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
 \par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
@@ -1560,17 +1556,16 @@ s/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-appl
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13511313 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid12588820 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12588820\charrsid12588820 \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.\hich\af2\dbch\af31505\loch\f2 com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScr\hich\af2\dbch\af31505\loch\f2 ipt >.\\ADDS_Inventory_V3.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
 \par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.gmail.com\hich\af2\dbch\af31505\loch\f2  on port 587 using SSL,
-\par \hich\af2\dbch\af31505\loch\f2     sending from webster@gmail.com, sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.gmail.com on port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     sending from webster@g\hich\af2\dbch\af31505\loch\f2 mail.com, sending to ITGroup@carlwebster.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
 \par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
@@ -1696,8 +1691,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000008075
-de468fa0d601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000f059
+1c969ee6d601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/ADDS_V3_Script_ChangeLog.txt
+++ b/ADDS_V3_Script_ChangeLog.txt
@@ -8,6 +8,18 @@
 #@essentialexch on Twitter
 #https://www.essential.exchange/blog/
 
+#Version 3.02 9-Jan-2021
+#	Added to the Computer Hardware section, the server's Power Plan
+#	Changed all Write-Verbose statements from Get-Date to Get-Date -Format G as requested by Guy Leech
+#	Clean up some spacing in the HTML output
+#	Fixed issue with the Services and OU tables where highlighted cells were not in red
+#	Fixed issue with the Word/PDF Domain Admins table with the missing Domain column
+#	In Function OutputTimeServerRegistryKeys, change the call to w32tm to use Invoke-Command to get around access denied errors
+#	Reordered parameters in an order recommended by Guy Leech
+#	Updated Exchange schema versions to include up to Exchange 2016 CU19 and Exchange 2019 CU8
+#	Updated help text
+#	Updated ReadMe file
+
 #Version 3.01 12-Oct-2020
 #	Handle the Domain Admins privileged group processing and output the same way the Enterprise and Schema Admins are done
 


### PR DESCRIPTION
#Version 3.02 9-Jan-2021
#	Added to the Computer Hardware section, the server's Power Plan
#	Changed all Write-Verbose statements from Get-Date to Get-Date -Format G as requested by Guy Leech
#	Clean up some spacing in the HTML output
#	Fixed issue with the Services and OU tables where highlighted cells were not in red
#	Fixed issue with the Word/PDF Domain Admins table with the missing Domain column
#	In Function OutputTimeServerRegistryKeys, change the call to w32tm to use Invoke-Command to get around access denied errors
#	Reordered parameters in an order recommended by Guy Leech
#	Updated Exchange schema versions to include up to Exchange 2016 CU19 and Exchange 2019 CU8
#	Updated help text
#	Updated ReadMe file