### PR TITLE
3.03

### DIFF
--- a/ADDS_Inventory_V3.ps1
+++ b/ADDS_Inventory_V3.ps1
@@ -37,7 +37,7 @@
 	You do NOT have to run this script on a domain controller. This script was developed 
 	and run from a Windows 10 VM.
 
-	While most of the script can be run with a non-admin account, there are some features 
+	While most of the script can run with a non-admin account, there are some features 
 	that will not or may not work without domain admin or enterprise admin rights.  
 	The Hardware and Services parameters require domain admin privileges.  
 	
@@ -73,23 +73,23 @@
 
 	Distinguished Name
 
-	Example: DC=tullahoma,DC=corp,DC=labaddomain,DC=com
+	Example: DC=labaddomain,DC=com
 
 	GUID (objectGUID)
 
-	Example: b9fa5fbd-4334-4a98-85f1-3a3a44069fc6
+	Example: b147a813-9938-4a89-bc93-58a0d36c41c3
 
 	Security Identifier (objectSid)
 
-	Example: S-1-5-21-3643273344-1505409314-3732760578
+	Example: S-1-5-21-3916992870-515249095-1421388220
 
 	DNS domain name
 
-	Example: tullahoma.corp.labaddomain.com
+	Example: labaddomain.com
 
 	NetBIOS domain name
 
-	Example: Tullahoma
+	Example: labaddomain
 
 	If both ADForest and ADDomain are specified, ADDomain takes precedence.
 .PARAMETER ADForest
@@ -100,7 +100,7 @@
 	Fully qualified domain name
 		Example: labaddomain.com
 	GUID (objectGUID)
-		Example: 599c3d2e-e61e-4d20-7b77-030d99495e19
+		Example: b147a813-9938-4a89-bc93-58a0d36c41c3
 	DNS host name
 		Example: labaddomain.com
 	NetBIOS name
@@ -443,6 +443,7 @@
 	
 	Because both ADForest and ADDomain are specified, ADDomain wins and child.company.tld 
 	is used for AD Domain.
+	
 	ADForest is set to the value of ADDomain.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
@@ -464,6 +465,7 @@
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
 	company.tld for the AD Forest
+	
 	The script runs remotely on the DC01 domain controller.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com
@@ -506,6 +508,7 @@
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -hardware
 	
 	Creates an HTML report.
+	
 	Uses all default values and adds additional information for each domain controller about 
 	its hardware.
 
@@ -518,6 +521,7 @@
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -services
 	
 	Creates an HTML report.
+	
 	Will use all default values and add additional information for the services running on 
 	each domain controller.
 
@@ -530,6 +534,7 @@
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -DCDNSInfo
 	
 	Creates an HTML report.
+	
 	Uses all default values and adds additional information for each domain controller about 
 	its DNS IP configuration.
 
@@ -704,7 +709,7 @@
 
 	The script uses the default SMTP port 25 and does not use SSL.
 
-	If the current user's credentials are not valid to send email, the script prompts 
+	If the current user's credentials are not valid to send an email, the script prompts 
 	the user to enter valid credentials.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -SmtpServer mailrelay.domain.tld -From 
@@ -768,8 +773,8 @@
 	The script uses the email server smtp.gmail.com on port 587 using SSL, sending from 
 	webster@gmail.com and sending to ITGroup@carlwebster.com.
 
-	If the current user's credentials are not valid to send email, the script prompts the 
-	user to enter valid credentials.
+	If the current user's credentials are not valid to send an email, the script prompts 
+	the user to enter valid credentials.
 .INPUTS
 	None.  You cannot pipe objects to this script.
 .OUTPUTS
@@ -778,7 +783,7 @@
 	NAME: ADDS_Inventory_V3.ps1
 	VERSION: 3.03
 	AUTHOR: Carl Webster and Michael B. Smith
-	LASTEDIT: February 18, 2021
+	LASTEDIT: February 20, 2021
 #>
 
 
@@ -925,7 +930,7 @@ Param(
 #	Added Domain SID to the Domain Information section
 #	Added SYSVOL State to Function OutputADFileLocations
 #		If SYSVOL State is not 4, highlight in red
-#	Added updates from MBS for MaxPasswordAge
+#	Added updates from Michael B. Smith for MaxPasswordAge
 #		Update Function getDSUsers
 #		Update Function GetMaximumPasswordAge
 #	Changed from using Test-Connection to Test-NetConnection -Port 88
@@ -1067,8 +1072,8 @@ Set-StrictMode -Version Latest
 
 #force on
 $PSDefaultParameterValues = @{"*:Verbose"=$True}
-#$SaveEAPreference = $ErrorActionPreference
-#$ErrorActionPreference = 'SilentlyContinue'
+$SaveEAPreference = $ErrorActionPreference
+$ErrorActionPreference = 'SilentlyContinue'
 $global:emailCredentials = $Null
 
 ## v3.00
@@ -1135,11 +1140,12 @@ If($Folder -ne "")
 		Else
 		{
 			#it exists but it is a file not a folder
+#Do not indent the following write-error lines. Doing so will mess up the console formatting of the error message.
 			Write-Error "
 			`n`n
-			`tFolder $Folder is a file, not a folder.
+	Folder $Folder is a file, not a folder.
 			`n`n
-			`tScript cannot Continue.
+	Script cannot continue.
 			`n`n"
 			Exit
 		}
@@ -1149,12 +1155,11 @@ If($Folder -ne "")
 		#does not exist
 		Write-Error "
 		`n`n
-		`t`t
-		Folder $Folder does not exist.
+	Folder $Folder does not exist.
 		`n`n
-		`t`t
-		Script cannot Continue.
-		`n`n"
+	Script cannot continue.
+		`n`n
+		"
 		Exit
 	}
 }
@@ -2797,7 +2802,7 @@ Function GetComputerServices
 	If($? -and $Null -ne $Services)
 	{
 		[int]$NumServices = $Services.count
-		Write-Verbose "$(Get-Date -Format G): `t`t$($NumServices) Services found"
+		Write-Verbose "$(Get-Date -Format G): `t`t`t$($NumServices) Services found"
 
 		If($MSWord -or $PDF)
 		{
@@ -6839,7 +6844,7 @@ Function SetFilenames
 Function ProcessScriptSetup
 {
 	#If hardware inventory or services are requested, make sure user is running the script with Domain Admin rights
-	Write-Verbose "$(Get-Date -Format G): `tTesting to see if $env:username has Domain Admin rights"
+	Write-Verbose "$(Get-Date -Format G): Testing to see if $env:username has Domain Admin rights"
 	
 	$AmIReallyDA = UserIsaDomainAdmin
 	If($AmIReallyDA -eq $True)
@@ -6847,11 +6852,11 @@ Function ProcessScriptSetup
 		#user has Domain Admin rights
 		If($ADDomain -ne "")
 		{
-			Write-Verbose "$(Get-Date -Format G): `t`t$env:username has Domain Admin rights in the $ADDomain Domain"
+			Write-Verbose "$(Get-Date -Format G): `t$env:username has Domain Admin rights in the $ADDomain Domain"
 		}
 		Else
 		{
-			Write-Verbose "$(Get-Date -Format G): `t`t$env:username has Domain Admin rights in the $ADForest Forest"
+			Write-Verbose "$(Get-Date -Format G): `t$env:username has Domain Admin rights in the $ADForest Forest"
 		}
 		$Script:DARights = $True
 	}
@@ -6860,11 +6865,11 @@ Function ProcessScriptSetup
 		#user does not have Domain Admin rights
 		If($ADDomain -ne "")
 		{
-			Write-Verbose "$(Get-Date -Format G): `t`t$env:username does not have Domain Admin rights in the $ADDomain Domain"
+			Write-Verbose "$(Get-Date -Format G): `t$env:username does not have Domain Admin rights in the $ADDomain Domain"
 		}
 		Else
 		{
-			Write-Verbose "$(Get-Date -Format G): `t`t$env:username does not have Domain Admin rights in the $ADForest Forest"
+			Write-Verbose "$(Get-Date -Format G): `t$env:username does not have Domain Admin rights in the $ADForest Forest"
 		}
 	}
 	
@@ -6872,11 +6877,12 @@ Function ProcessScriptSetup
 	
 	If($Hardware -or $Services -or $DCDNSInfo)
 	{
-		If($Hardware -and -not $Services)
+		If($Hardware)
 		{
 			Write-Verbose "$(Get-Date -Format G): Hardware inventory requested"
 		}
-		If($Services -and -not $Hardware)
+
+		If($Services)
 		{
 			Write-Verbose "$(Get-Date -Format G): Services requested"
 		}
@@ -7102,7 +7108,7 @@ please run the script from an elevated PowerShell session using an account with 
 				Exit
 			}
 		}
-		Write-Verbose "$(Get-Date -Format G): $ADForest is a valid forest name"
+		Write-Verbose "$(Get-Date -Format G): `t$ADForest is a valid forest name"
 		[string]$Script:Title = "AD Inventory Report for the $ADForest Forest"
 		$Script:Domains       = $Script:Forest.Domains | Sort-Object 
 		$Script:ConfigNC      = (Get-ADRootDSE -Server $ADForest -EA 0).ConfigurationNamingContext
@@ -7110,6 +7116,7 @@ please run the script from an elevated PowerShell session using an account with 
 	
 	If($ADDomain -ne "")
 	{
+		Write-Verbose "$(Get-Date -Format G): Testing to see if $($ADDomain) is a valid domain name"
 		If([String]::IsNullOrEmpty($ComputerName))
 		{
 			$results = Get-ADDomain -Identity $ADDomain -EA 0
@@ -7151,7 +7158,7 @@ please run the script from an elevated PowerShell session using an account with 
 				Exit
 			}
 		}
-		Write-Verbose "$(Get-Date -Format G): $ADDomain is a valid domain name"
+		Write-Verbose "$(Get-Date -Format G): `t$ADDomain is a valid domain name"
 		$Script:Domains       = $results.DNSRoot
 		$Script:DomainDNSRoot = $results.DNSRoot
 		[string]$Script:Title = "AD Inventory Report for the $Script:Domains Domain"
@@ -7200,7 +7207,7 @@ please run the script from an elevated PowerShell session using an account with 
 				Exit
 			}
 		}
-		Write-Verbose "$(Get-Date -Format G): Found forest information for $tmp"
+		Write-Verbose "$(Get-Date -Format G): `tFound forest information for $tmp"
 		$Script:ConfigNC = (Get-ADRootDSE -Server $tmp -EA 0).ConfigurationNamingContext
 	}
 	
@@ -11399,7 +11406,7 @@ Function OutputTimeServerRegistryKeys
 		[String] $DCName
 	)
 	
-	Write-Verbose "$(Get-Date -Format G): `tTimeServer Registry Keys"
+	Write-Verbose "$(Get-Date -Format G): `t`tTimeServer Registry Keys"
 	#HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\Config	AnnounceFlags
 	#HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\Config	MaxNegPhaseCorrection
 	#HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\Config	MaxPosPhaseCorrection
@@ -11571,7 +11578,7 @@ Function OutputADFileLocations
 		[String] $DCName 
 	)
 	
-	Write-Verbose "$(Get-Date -Format G): `tAD Database, Logfile and SYSVOL locations"
+	Write-Verbose "$(Get-Date -Format G): `t`tAD Database, Logfile and SYSVOL locations"
 	#HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NTDS\Parameters	'DSA Database file'
 	#HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NTDS\Parameters	'Database log files path'
 	#HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters	SysVol
@@ -11732,7 +11739,7 @@ Function OutputEventLogInfo
 		[String] $DCName 
 	)
 	
-	Write-Verbose "$(Get-Date -Format G): `tEvent Log Information"
+	Write-Verbose "$(Get-Date -Format G): `t`tEvent Log Information"
 	$ELInfo = $null ## New-Object System.Collections.ArrayList ## FIXME - make this an array instead of arraylist
 	
 	#V3.00 - note that we are sorted here by name, don't need to sort again later.
@@ -14319,6 +14326,9 @@ Function ProcessgGPOsByOUOld
 		[int]$NumOUs = $OUs.Count
 		[int]$OUCount = 0
 
+		#V3.03
+		Write-Verbose "$(Get-Date -Format G): `tThere are $NumOUs OUs in domain $($Domain)"
+
 		ForEach($OU in $OUs)
 		{
 			$OUCount++
@@ -14916,7 +14926,7 @@ Function getDSUsers
 	$null         = GetMaximumPasswordAge
 	$now          = Get-Date
 
-    Write-Verbose "$(Get-Date -Format G): `t`tGathering user misc data"
+    Write-Verbose "$(Get-Date -Format G): `t`tGathering user misc data #1"
 
     ## see MBS Get-myUserInfo.ps1 for the full list
     $ADS_UF_ACCOUNTDISABLE                          = 2        ### 0x2
@@ -15997,7 +16007,7 @@ Function ProcessMiscDataByDomain
 			WriteHTMLLine 2 0 "///&nbsp;&nbsp;$($txt)&nbsp;&nbsp;\\\"
 		}
 
-		Write-Verbose "$(Get-Date -Format G): `t`tGathering user misc data"
+		Write-Verbose "$(Get-Date -Format G): `t`tGathering user misc data #2"
 		
 		getDSUsers $Domain
 

--- a/ADDS_Inventory_V3.ps1
+++ b/ADDS_Inventory_V3.ps1
@@ -15,7 +15,7 @@
 	
 	Version 3.0 changes the default output report from Word to HTML.
 	
-	Word and PDF document includes a Cover Page, Table of Contents and Footer.
+	Word and PDF document includes a Cover Page, Table of Contents, and Footer.
 	Includes support for the following language versions of Microsoft Word:
 		Catalan
 		Chinese
@@ -32,7 +32,7 @@
 
 	The script requires at least PowerShell version 3 but runs best in version 5.
 
-	Word is NOT needed to run the script. This script will output in Text and HTML.
+	Word is NOT needed to run the script. This script outputs in Text and HTML.
 	
 	You do NOT have to run this script on a domain controller. This script was developed 
 	and run from a Windows 10 VM.
@@ -113,7 +113,7 @@
 	Specifies which domain controller to use to run the script against.
 	If ADForest is a trusted forest, then ComputerName is required to detect the 
 	existence of ADForest.
-	ComputerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
+	ComputerName can be entered as the NetBIOS name, FQDN, localhost, or IP Address.
 	If entered as localhost, the actual computer name is determined and used.
 	If entered as an IP address, an attempt is made to determine and use the actual 
 	computer name.
@@ -159,7 +159,7 @@
 	Outputs all errors to a text file at the end of the script.
 	
 	This is used when the script developer requests more troubleshooting data.
-	The text file is placed in the same folder from where the script is run.
+	The text file is placed in the same folder from where the script runs.
 	
 	This parameter is disabled by default.
 .PARAMETER Folder
@@ -168,34 +168,36 @@
 	Generates a log file for troubleshooting.
 .PARAMETER ScriptInfo
 	Outputs information about the script to a text file.
-	The text file is placed in the same folder from where the script is run.
+	The text file is placed in the same folder from where the script runs.
 	
 	This parameter is disabled by default.
 	This parameter has an alias of SI.
 .PARAMETER DCDNSInfo 
 	Use WMI to gather, for each domain controller, the IP Address, and each DNS server 
 	configured.
-	This parameter requires the script be run from an elevated PowerShell session 
-	using an account with permission to retrieve hardware information (i.e. Domain 
+	This parameter requires the script to run from an elevated PowerShell session 
+	using an account with permission to retrieve hardware information (i.e., Domain 
 	Admin).
-	Selecting this parameter will add an extra section to the report.
+	Selecting this parameter adds an extra section to the report.
 	This parameter is disabled by default.
 .PARAMETER GPOInheritance
-	In the Group Policies by OU section, adds Inherited GPOs in addition to the GPOs 
+	In the Group Policies by OU section adds Inherited GPOs in addition to the GPOs 
 	directly linked.
 	Adds a second column to the table GPO Type.
-	The text file is placed in the same folder from where the script is run.
 	
 	This parameter is disabled by default.
 	This parameter has an alias of GPO.
 .PARAMETER Hardware
 	Use WMI to gather hardware information on Computer System, Disks, Processor, and 
 	Network Interface Cards
-	This parameter requires the script be run from an elevated PowerShell session 
-	using an account with permission to retrieve hardware information (i.e. Domain 
+	
+	This parameter requires the script to run from an elevated PowerShell session 
+	using an account with permission to retrieve hardware information (i.e., Domain 
 	Admin).
+	
 	Selecting this parameter will add to both the time it takes to run the script and 
 	size of the report.
+	
 	This parameter is disabled by default.
 .PARAMETER IncludeUserInfo
 	For the User Miscellaneous Data section outputs a table with the SamAccountName
@@ -212,6 +214,7 @@
 		All users with Homedrive set in ADUC
 		All users whose Primary Group is not Domain Users
 		All users with RDS HomeDrive set in ADUC
+		All Names in the ForeignSecurityPrincipals container that are orphan SIDs
 	
 	The Text output option is limited to the first 25 characters of the SamAccountName
 	and the first 116 characters of the DistinguishedName.
@@ -313,7 +316,7 @@
 	This parameter has an alias of CPh.
 .PARAMETER CoverPage
 	What Microsoft Word Cover Page to use.
-	Only Word 2010, 2013 and 2016 are supported.
+	Only Word 2010, 2013, and 2016 are supported.
 	(default cover pages in Word en-US)
 	
 	Valid input is:
@@ -396,7 +399,7 @@
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -MSWord
 	
-	Will use all default values.
+	Uses all default values.
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
 	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
@@ -409,8 +412,8 @@
 	ADForest defaults to the value of $Env:USERDNSDOMAIN.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -ADForest company.tld
 	
@@ -419,8 +422,8 @@
 	company.tld for the AD Forest.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -ADDomain 
 	child.company.tld
@@ -430,8 +433,8 @@
 	child.company.tld for the AD Domain.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -ADForest parent.company.tld -ADDomain 
 	child.company.tld
@@ -443,15 +446,15 @@
 	ADForest is set to the value of ADDomain.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -ADForest company.tld -ComputerName DC01 
 	-MSWord
 	
 	Creates a Microsoft Word report.
 	
-	Will use all default values.
+	Uses all default values.
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
 	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
@@ -461,11 +464,11 @@
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
 	company.tld for the AD Forest
-	The script will be run remotely on the DC01 domain controller.
+	The script runs remotely on the DC01 domain controller.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com
 	
-	Will use all default values and save the document as a PDF file.
+	Uses all default values and saves the document as a PDF file.
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
 	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
@@ -477,66 +480,66 @@
 	corp.carlwebster.com for the AD Forest.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -Text -ADForest corp.carlwebster.com
 	
-	Will use all default values and save the document as a formatted text file.
+	Uses all default values and saves the document as a formatted text file.
 
 	corp.carlwebster.com for the AD Forest.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -HTML -ADForest corp.carlwebster.com
 	
-	Will use all default values and save the document as an HTML file.
+	Uses all default values and saves the document as an HTML file.
 
 	corp.carlwebster.com for the AD Forest.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -hardware
 	
 	Creates an HTML report.
-	Will use all default values and add additional information for each domain controller 
-	about its hardware.
+	Uses all default values and adds additional information for each domain controller about 
+	its hardware.
 
 	ADForest defaults to the value of $Env:USERDNSDOMAIN.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -services
 	
 	Creates an HTML report.
-	Will use all default values and add additional information for the services running 
-	on each domain controller.
+	Will use all default values and add additional information for the services running on 
+	each domain controller.
 
 	ADForest defaults to the value of $Env:USERDNSDOMAIN.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -DCDNSInfo
 	
 	Creates an HTML report.
-	Will use all default values and add additional information for each domain controller 
-	about its DNS IP configuration.
+	Uses all default values and adds additional information for each domain controller about 
+	its DNS IP configuration.
 
-	An extra section will be added to the end of the report.
+	An extra section is added to the end of the report.
 
 	ADForest defaults to the value of $Env:USERDNSDOMAIN.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 .EXAMPLE
 	PS C:\PSScript .\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster 
 	Consulting" -CoverPage "Mod" -UserName "Carl Webster" -ComputerName ADDC01
@@ -565,8 +568,8 @@
 	ADForest defaults to the value of $Env:USERDNSDOMAIN.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 .EXAMPLE
 	PS C:\PSScript .\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes 
     Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker 
@@ -585,8 +588,8 @@
 	ADForest defaults to the value of $Env:USERDNSDOMAIN.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 .EXAMPLE
 	PS C:\PSScript .\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes 
 	Consulting" -CoverPage Facet -UserName "Dr. Watson" -CompanyEmail 
@@ -603,8 +606,8 @@
 	ADForest defaults to the value of $Env:USERDNSDOMAIN.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -ADForest company.tld -AddDateTime
 	
@@ -613,18 +616,18 @@
 	company.tld for the AD Forest.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 
 	Adds a date time stamp to the end of the file name.
 	The timestamp is in the format of yyyy-MM-dd_HHmm.
 	June 1, 2021 at 6PM is 2021-06-01_1800.
-	Output filename will be company.tld_2021-06-01_1800.docx.
+	The output filename is company.tld_2021-06-01_1800.docx.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com 
 	-AddDateTime
 	
-	Will use all default values and save the document as a PDF file.
+	Uses all default values and saves the document as a PDF file.
 
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
 	Webster" or
@@ -637,13 +640,13 @@
 	corp.carlwebster.com for the AD Forest.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 
 	Adds a date time stamp to the end of the file name.
 	The timestamp is in the format of yyyy-MM-dd_HHmm.
 	June 1, 2021 at 6PM is 2021-06-01_1800.
-	Output filename will be corp.carlwebster.com_2021-06-01_1800.PDF
+	The output filename is corp.carlwebster.com_2021-06-01_1800.PDF
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -ADForest corp.carlwebster.com -Folder 
 	\\FileServer\ShareName
@@ -653,10 +656,10 @@
 	corp.carlwebster.com for the AD Forest.
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 	
-	The output file will be saved in the path \\FileServer\ShareName.
+	The output file is saved in the path \\FileServer\ShareName.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -Section Forest
 
@@ -665,10 +668,10 @@
 	ADForest defaults to the value of $Env:USERDNSDOMAIN
 
 	ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for 
-	a domain controller that is also a global catalog server and will use that as the 
-	value for ComputerName.
+	a domain controller that is also a global catalog server and uses that as the value 
+	for ComputerName.
 	
-	The report will include only the Forest section.
+	The report includes only the Forest section.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -Section groups, misc -ADForest 
 	WebstersLab.com -ServerName PrimaryDC.websterslab.com
@@ -678,7 +681,7 @@
 	WebstersLab.com for ADForest.
 	PrimaryDC.websterslab.com for ComputerName.
 	
-	The report will include only the Groups and Miscellaneous sections.
+	The report includes only the Groups and Miscellaneous sections.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -MaxDetails
 	
@@ -694,38 +697,38 @@
 		Section         = "All"
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -SmtpServer mail.domain.tld -From 
-	XDAdmin@domain.tld -To ITGroup@domain.tld	
+	ADAdmin@domain.tld -To ITGroup@domain.tld	
 
-	The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld, 
-	sending to ITGroup@domain.tld.
+	The script uses the email server mail.domain.tld, sending from ADAdmin@domain.tld 
+	and sending to ITGroup@domain.tld.
 
-	The script will use the default SMTP port 25 and will not use SSL.
+	The script uses the default SMTP port 25 and does not use SSL.
 
-	If the current user's credentials are not valid to send email, 
-	the user will be prompted to enter valid credentials.
+	If the current user's credentials are not valid to send email, the script prompts 
+	the user to enter valid credentials.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -SmtpServer mailrelay.domain.tld -From 
 	Anonymous@domain.tld -To ITGroup@domain.tld	
 
 	***SENDING UNAUTHENTICATED EMAIL***
 
-	The script will use the email server mailrelay.domain.tld, sending from 
-	anonymous@domain.tld, sending to ITGroup@domain.tld.
+	The script uses the email server mailrelay.domain.tld, sending from 
+	anonymous@domain.tld and sending to ITGroup@domain.tld.
 
-	To send unauthenticated email using an email relay server requires the From email account 
-	to use the name Anonymous.
+	To send an unauthenticated email using an email relay server requires the From email 
+	account to use the name Anonymous.
 
-	The script will use the default SMTP port 25 and will not use SSL.
+	The script uses the default SMTP port 25 and does not use SSL.
 	
 	***GMAIL/G SUITE SMTP RELAY***
 	https://support.google.com/a/answer/2956491?hl=en
 	https://support.google.com/a/answer/176600?hl=en
 
-	To send email using a Gmail or g-suite account, you may have to turn ON
-	the "Less secure app access" option on your account.
+	To send an email using a Gmail or g-suite account, you may have to turn ON the "Less 
+	secure app access" option on your account.
 	***GMAIL/G SUITE SMTP RELAY***
 
-	The script will generate an anonymous secure password for the anonymous@domain.tld 
+	The script generates an anonymous, secure password for the anonymous@domain.tld 
 	account.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -SmtpServer 
@@ -740,42 +743,42 @@
 	
 	***OFFICE 365 Example***
 
-	The script will use the email server labaddomain-com.mail.protection.outlook.com, 
-	sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
+	The script uses the email server labaddomain-com.mail.protection.outlook.com, sending 
+	from SomeEmailAddress@labaddomain.com and sending to ITGroupDL@labaddomain.com.
 
-	The script will use the default SMTP port 25 and will use SSL.
+	The script uses the default SMTP port 25 and SSL.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -SmtpServer smtp.office365.com -SmtpPort 587 
 	-UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com	
 
-	The script will use the email server smtp.office365.com on port 587 using SSL, 
-	sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
+	The script uses the email server smtp.office365.com on port 587 using SSL, sending from 
+	webster@carlwebster.com and sending to ITGroup@carlwebster.com.
 
-	If the current user's credentials are not valid to send email, 
-	the user will be prompted to enter valid credentials.
+	If the current user's credentials are not valid to send an email, the script prompts 
+	the user to enter valid credentials.
 .EXAMPLE
 	PS C:\PSScript > .\ADDS_Inventory_V3.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587 
 	-UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com	
 
 	*** NOTE ***
-	To send email using a Gmail or g-suite account, you may have to turn ON
-	the "Less secure app access" option on your account.
+	To send an email using a Gmail or g-suite account, you may have to turn ON the "Less 
+	secure app access" option on your account.
 	*** NOTE ***
 	
-	The script will use the email server smtp.gmail.com on port 587 using SSL, 
-	sending from webster@gmail.com, sending to ITGroup@carlwebster.com.
+	The script uses the email server smtp.gmail.com on port 587 using SSL, sending from 
+	webster@gmail.com and sending to ITGroup@carlwebster.com.
 
-	If the current user's credentials are not valid to send email, 
-	the user will be prompted to enter valid credentials.
+	If the current user's credentials are not valid to send email, the script prompts the 
+	user to enter valid credentials.
 .INPUTS
 	None.  You cannot pipe objects to this script.
 .OUTPUTS
 	No objects are output from this script.  This script creates a Word or PDF document.
 .NOTES
 	NAME: ADDS_Inventory_V3.ps1
-	VERSION: 3.02
+	VERSION: 3.03
 	AUTHOR: Carl Webster and Michael B. Smith
-	LASTEDIT: January 9, 2021
+	LASTEDIT: February 18, 2021
 #>
 
 
@@ -917,6 +920,37 @@ Param(
 #
 #Version 2.0 is based on version 1.20
 #
+#Version 3.03 22-Feb-2021
+#	Added a Try/Catch and -LDAPFilter when checking for the Exchange schema attributes to suppress the error if Exchange is not installed
+#	Added Domain SID to the Domain Information section
+#	Added SYSVOL State to Function OutputADFileLocations
+#		If SYSVOL State is not 4, highlight in red
+#	Added updates from MBS for MaxPasswordAge
+#		Update Function getDSUsers
+#		Update Function GetMaximumPasswordAge
+#	Changed from using Test-Connection to Test-NetConnection -Port 88
+#		Port 88 is the KDC and is unique to DCs (thanks to Matthew Woolnough for the suggestion)
+#	Cleaned up console output
+#	In Function BuildMultiColumnTable:
+#		Prevent a division by 0 error if $MaxLength was 0
+#		Fixed OutOfBounds array error (appears to be a corner case when there are 11 subnets assigned to a Site)
+#	Fixed bug to now catch empty Site Subnet arrays
+#		Added text "No Subnets linked to this site"
+#	Updated Function GetComputerServices to add "***" in the Text output when the service type is Automatic and Status is Stopped
+#	Updated Function getDSUsers to handle processing accounts in the Foreign Security Principals container
+#		Find all orphaned SIDs
+#		Get a count of orphaned SIDs
+#		Added Function OutputFSPUserInfo to output the Orphaned SIDs and the groups those SIDs are members of
+#	Updated Function ProcessGroupInformation to put HTML output in Red when:
+#		Password Last Change is null or not set
+#		Password Never Expires is True
+#		Account is Disabled
+#	Updated the help text
+#	Updated the ReadMe file
+#	When processing Groups for attribute adminCount -eq 1, fixed where the group name doesn’t match the samAccountName or the distinguishedName
+#	When processing Groups that have attribute adminCount -eq 1, check if there was an error retrieving members of the group
+#		If there was an error, add the text "Unable to retrieve group members. Check for orphaned SIDs." in place of the group members
+#
 #Version 3.02 9-Jan-2021
 #	Added to the Computer Hardware section, the server's Power Plan
 #	Changed all Write-Verbose statements from Get-Date to Get-Date -Format G as requested by Guy Leech
@@ -1033,13 +1067,13 @@ Set-StrictMode -Version Latest
 
 #force on
 $PSDefaultParameterValues = @{"*:Verbose"=$True}
-$SaveEAPreference = $ErrorActionPreference
-$ErrorActionPreference = 'SilentlyContinue'
+#$SaveEAPreference = $ErrorActionPreference
+#$ErrorActionPreference = 'SilentlyContinue'
 $global:emailCredentials = $Null
 
 ## v3.00
 $script:ExtraSpecialVerbose = $false
-$script:MyVersion           = '3.00'
+$script:MyVersion           = '3.03'
 
 Function wv
 {
@@ -2833,7 +2867,14 @@ Function GetComputerServices
 				{
 					Line 1 "$($Service.DisplayName)  " -NoNewLine
 				}
-				Line 1 "$($Service.State) " -NoNewLine
+				If($Service.State -like "Stopped" -and $Service.StartMode -like "Auto") 
+				{
+					Line 1 "***$($Service.State)*** " -NoNewLine
+				}
+				Else
+				{
+					Line 1 "$($Service.State) " -NoNewLine
+				}
 				Line 1 $Service.StartMode
 			}
 			If($HTML)
@@ -2862,7 +2903,10 @@ Function GetComputerServices
 			-AutoFit $wdAutoFitContent;
 
 			SetWordCellFormat -Collection $Table.Rows.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
-			SetWordCellFormat -Coordinates $WordHighlightedCells -Table $Table -Bold -BackgroundColor $wdColorRed -Solid;
+			If($WordHighlightedCells.Count -gt 0)
+			{
+				SetWordCellFormat -Coordinates $WordHighlightedCells -Table $Table -Bold -BackgroundColor $wdColorRed -Solid;
+			}
 
 			$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
 
@@ -5680,18 +5724,20 @@ Function AbortScript
 
 Function BuildMultiColumnTable
 {
-	Param([Array]$xArray, [String]$xType)
+	Param([Array]$xArray)
 	
 	#divide by 0 bug reported 9-Apr-2014 by Lee Dehmer 
 	#if security group name or OU name was longer than 60 characters it caused a divide by 0 error
 	
 	#added a second parameter to the Function so the verbose message would say whether 
 	#the Function is processing servers, security groups or OUs.
+	#V3.03, remove the second parameter as it was no longer needed or used
 	
 	If(-not ($xArray -is [Array]))
 	{
 		$xArray = (,$xArray)
 	}
+	
 	[int]$MaxLength = 0
 	[int]$TmpLength = 0
 	#remove 60 as a hard-coded value
@@ -5707,7 +5753,16 @@ Function BuildMultiColumnTable
 	}
 	$TableRange = $doc.Application.Selection.Range
 	#removed hard-coded value of 60 and replace with MaxTableWidth variable
-	[int]$Columns = [Math]::Floor($MaxTableWidth / $MaxLength)
+	#fix in 3.03 if $MaxLength was 0, prevent division by 0
+	If($MaxLength -eq 0)
+	{
+		[int]$Columns = 0
+	}
+	Else
+	{
+		[int]$Columns = [Math]::Floor($MaxTableWidth / $MaxLength)
+	}
+	
 	If($xArray.count -lt $Columns)
 	{
 		[int]$Rows = 1
@@ -5744,12 +5799,16 @@ Function BuildMultiColumnTable
 		{
 			$Table.Cell($xRow,$xCell).Range.Text = $xArray[$ArrayItem]
 			$ArrayItem++
+			If($ArrayItem -eq $xArray.Count) #fix in 3.03 to catch a weird array out of bounds error
+			{
+				Break
+			}
 		}
 		$xRow++
 	}
 	$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustNone)
 	$Table.AutoFitBehavior($wdAutoFitContent)
-
+	
 	FindWordDocumentEnd
 	$TableRange = $Null
 	$Table = $Null
@@ -5761,7 +5820,7 @@ Function UserIsaDomainAdmin
 	#Function adapted from sample code provided by Thomas Vuylsteke
 	$IsDA = $False
 	$name = $env:username
-	Write-Verbose "$(Get-Date -Format G): TokenGroups - Checking groups for $name"
+	Write-Verbose "$(Get-Date -Format G): `t`tTokenGroups - Checking groups for $name"
 
 	$root = [ADSI]""
 	$filter = "(sAMAccountName=$name)"
@@ -6788,11 +6847,11 @@ Function ProcessScriptSetup
 		#user has Domain Admin rights
 		If($ADDomain -ne "")
 		{
-			Write-Verbose "$(Get-Date -Format G): $env:username has Domain Admin rights in the $ADDomain Domain"
+			Write-Verbose "$(Get-Date -Format G): `t`t$env:username has Domain Admin rights in the $ADDomain Domain"
 		}
 		Else
 		{
-			Write-Verbose "$(Get-Date -Format G): $env:username has Domain Admin rights in the $ADForest Forest"
+			Write-Verbose "$(Get-Date -Format G): `t`t$env:username has Domain Admin rights in the $ADForest Forest"
 		}
 		$Script:DARights = $True
 	}
@@ -6801,11 +6860,11 @@ Function ProcessScriptSetup
 		#user does not have Domain Admin rights
 		If($ADDomain -ne "")
 		{
-			Write-Verbose "$(Get-Date -Format G): $env:username does not have Domain Admin rights in the $ADDomain Domain"
+			Write-Verbose "$(Get-Date -Format G): `t`t$env:username does not have Domain Admin rights in the $ADDomain Domain"
 		}
 		Else
 		{
-			Write-Verbose "$(Get-Date -Format G): $env:username does not have Domain Admin rights in the $ADForest Forest"
+			Write-Verbose "$(Get-Date -Format G): `t`t$env:username does not have Domain Admin rights in the $ADForest Forest"
 		}
 	}
 	
@@ -6940,9 +6999,10 @@ please run the script from an elevated PowerShell session using an account with 
 		#get server name
 		#first test to make sure the server is reachable
 		Write-Verbose "$(Get-Date -Format G): Testing to see if $ComputerName is online and reachable"
-		If(Test-Connection -ComputerName $ComputerName -quiet -EA 0)
+		#If(Test-Connection -ComputerName $ComputerName -quiet -EA 0)
+		If(Test-NetConnection -ComputerName $ComputerName -Port 88 -InformationLevel Quiet -EA 0) #port 88 is the KDC and is unique to DCs (thanks to Matthew Woolnough)
 		{
-			Write-Verbose "$(Get-Date -Format G): Server $ComputerName is online."
+			Write-Verbose "$(Get-Date -Format G): `tServer $ComputerName is online."
 			Write-Verbose "$(Get-Date -Format G): `tTest #1 to see if $ComputerName is a Domain Controller."
 			#the server may be online but is it really a domain controller?
 
@@ -7401,7 +7461,6 @@ Function ProcessForestInformation
 		}
 		$tmp = $Null
 
-		Write-Verbose "$(Get-Date -Format G): `t`tCreate Forest Word table"
 		$Table = AddWordTable -Hashtable $ScriptInformation `
 		-Columns Data,Value `
 		-List `
@@ -7950,7 +8009,6 @@ Function ProcessAllDCsInTheForest
 
 	If($MSWord -or $PDF)
 	{
-		Write-Verbose "$(Get-Date -Format G): `t`tCreate Domain Controller in Forest Word table"
 		$Table = AddWordTable -Hashtable $WordTableRowHash `
 		-Columns DCName, GC, ReadOnly, ServerOS, ServerCore `
 		-Headers "Name", "Global Catalog", "Read-only", "Server OS", "Server Core" `
@@ -8048,7 +8106,6 @@ Function ProcessCAInformation
 				[System.Collections.Hashtable[]] $ScriptInformation = @()
 				$ScriptInformation += @{ Data = "Common name"; Value = $obj.cn; }
 				$ScriptInformation += @{ Data = "Distinguished name"; Value = $obj.distinguishedName; }
-				Write-Verbose "$(Get-Date -Format G): `t`tCreate Certification Authority Root(s) Word table"
 				$Table = AddWordTable -Hashtable $ScriptInformation `
 				-Columns Data,Value `
 				-List `
@@ -8179,7 +8236,6 @@ Function ProcessCAInformation
 				[System.Collections.Hashtable[]] $ScriptInformation = @()
 				$ScriptInformation += @{ Data = "Common name"; Value = $obj.cn; }
 				$ScriptInformation += @{ Data = "Distinguished name"; Value = $obj.distinguishedName; }
-				Write-Verbose "$(Get-Date -Format G): `t`tCreate CA Authorities Word table"
 				$Table = AddWordTable -Hashtable $ScriptInformation `
 				-Columns Data,Value `
 				-List `
@@ -8342,7 +8398,6 @@ Function ProcessADOptionalFeatures
 						}
 					}
 				}
-				Write-Verbose "$(Get-Date -Format G): `t`tCreate AD Optional Features Word table"
 				$Table = AddWordTable -Hashtable $ScriptInformation `
 				-Columns Data,Value `
 				-List `
@@ -8832,7 +8887,6 @@ Function ProcessSiteInformation
 					$ScriptInformation += @{ Data = "Options"; Value = $tmp; }
 					$ScriptInformation += @{ Data = "Type"; Value = $SiteLinkType; }
 
-					Write-Verbose "$(Get-Date -Format G): `t`t`tCreate Site Links Word table"
 					$Table = AddWordTable -Hashtable $ScriptInformation `
 					-Columns Data,Value `
 					-List `
@@ -9022,29 +9076,31 @@ Function ProcessSiteInformation
 				$i++
 			}
 			$subnetArray = @( $subnetArray | Sort-Object )
-			If($Null -eq $subnetArray)
+			#Fix in 3.03 to catch an empty array
+			If($Null -eq $subnetArray -or $subnetArray.Count -eq 0)
 			{
 				If($MSWord -or $PDF)
 				{
-					WriteWordLine 0 0 "<None>"
+					WriteWordLine 0 0 "No Subnets linked to this site"
 				}
 				If($Text)
 				{
-					Line 2 "<None>"
+					Line 2 "No Subnets linked to this site"
 					Line 0 ""
 				}
 				If($HTML)
 				{
-					WriteHTMLLine 0 0 "None"
+					WriteHTMLLine 0 0 "No Subnets linked to this site"
 				}
 			}
 			Else
 			{
+				Write-Verbose "$(Get-Date -Format G): `t`t`tSite $( $site.Name ) has $( $subnetArray.Count ) subnets"
 				If($MSWord -or $PDF)
 				{
-					BuildMultiColumnTable $subnetArray "Subnets"
+					BuildMultiColumnTable $subnetArray
 				}
-				If($text)
+				If($Text)
 				{
 					ForEach($xSubnet in $subnetArray)
 					{
@@ -9054,7 +9110,6 @@ Function ProcessSiteInformation
 				}
 				If($HTML)
 				{
-					Write-Verbose "$(Get-Date -Format G): `t`tSite $( $site.Name ) has $( $subnetArray.Count ) subnets"
 					$rowdata = New-Object System.Array[] $subnetArray.Count
 					$rowIndx = 0
 
@@ -9579,8 +9634,19 @@ Function ProcessDomains
 			
 			If($Domain -eq $Script:ForestRootDomain)
 			{
-				$ExchangeSchemaInfo = Get-ADObject "cn=ms-exch-schema-version-pt,cn=Schema,cn=Configuration,$($DomainInfo.DistinguishedName)" `
-				-properties rangeupper -Server $Domain -EA 0
+				#try/catch and -LDAPFilter added in 3.03 to suppress the error 
+				#Get-ADObject : Directory object not found
+				#+ ... chemaInfo = Get-ADObject "cn=ms-exch-schema-version-pt,cn=Schema,cn=C ...				
+				try
+				{
+					$ExchangeSchemaInfo = Get-ADObject -LDAPFilter "cn=ms-exch-schema-version-pt,cn=Schema,cn=Configuration,$($DomainInfo.DistinguishedName)" `
+					-properties rangeupper -Server $Domain -EA 0
+				}
+				
+				catch
+				{
+					#do nothing but suppress the error message if Exchange is not installed in the domain
+				}
 
 				If($? -and $Null -ne $ExchangeSchemaInfo)
 				{
@@ -9664,6 +9730,7 @@ Function ProcessDomains
 				$ScriptInformation += @{ Data = "Distinguished name"; Value = $DomainInfo.DistinguishedName; }
 				$ScriptInformation += @{ Data = "DNS root"; Value = $DomainInfo.DNSRoot; }
 				$ScriptInformation += @{ Data = "Domain controllers container"; Value = $DomainInfo.DomainControllersContainer; }
+				$ScriptInformation += @{ Data = "Domain SID"; Value = $DomainInfo.DomainSID; }
 				If(![String]::IsNullOrEmpty($ExchangeSchemaInfo))
 				{
 					$ScriptInformation += @{ Data = "Exchange Schema"; Value = "($($ExchangeSchemaVersion)) - $($ExchangeSchemaVersionName)"; }
@@ -9826,6 +9893,7 @@ Function ProcessDomains
 				Line 1 "Distinguished name`t`t`t: " $DomainInfo.DistinguishedName
 				Line 1 "DNS root`t`t`t`t: " $DomainInfo.DNSRoot
 				Line 1 "Domain controllers container`t`t: " $DomainInfo.DomainControllersContainer
+				Line 1 "Domain SID`t`t`t`t: " $DomainInfo.DomainSID
 				If(![String]::IsNullOrEmpty($ExchangeSchemaInfo))
 				{
 					Line 1 "Exchange Schema`t`t`t`t: ($($ExchangeSchemaVersion)) - $($ExchangeSchemaVersionName)"
@@ -9974,6 +10042,7 @@ Function ProcessDomains
 				$rowdata += @(,('Distinguished name',$htmlsb,$DomainInfo.DistinguishedName,$htmlwhite))
 				$rowdata += @(,('DNS root',$htmlsb,$DomainInfo.DNSRoot,$htmlwhite))
 				$rowdata += @(,('Domain controllers container',$htmlsb,$DomainInfo.DomainControllersContainer,$htmlwhite))
+				$rowdata += @(,('Domain SID',$htmlsb,$DomainInfo.DomainSID,$htmlwhite))
 				If(![String]::IsNullOrEmpty($ExchangeSchemaInfo))
 				{
 					$rowdata += @(,('Exchange Schema',$htmlsb,"($($ExchangeSchemaVersion)) - $($ExchangeSchemaVersionName)",$htmlwhite))
@@ -11233,7 +11302,8 @@ Function ProcessDomainControllers
 		
 		If($Hardware -or $Services -or $DCDNSInfo)
 		{
-			If(Test-Connection -ComputerName $DC.HostName -quiet -EA 0)
+			#If(Test-Connection -ComputerName $DC.HostName -quiet -EA 0)
+			If(Test-NetConnection -ComputerName $ComputerName -Port 88 -InformationLevel Quiet -EA 0) #port 88 is the KDC and is unique to DCs (thanks to Matthew Woolnough)
 			{
 				If($Hardware)
 				{
@@ -11511,12 +11581,44 @@ Function OutputADFileLocations
 	{
 		$DSADatabaseFile = ''
 		$DatabaseLogFilesPath = ''
-		$SysVol = ''
+		$Sysvol = ''
+		$SysvolState = 'Unknown'
 	}
 	Else
 	{
 		$DatabaseLogFilesPath = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters" "Database log files path" $DCName
-		$SysVol = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters" "SysVol" $DCName
+		$Sysvol = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters" "SysVol" $DCName
+
+		$Result = Get-WMIObject -ComputerName $DCName -Namespace "root/microsoftdfs" -Class "dfsrreplicatedfolderinfo" -Filter "ReplicatedFolderName = 'SYSVOL Share'" -EA 0 | Select-Object State
+
+		If($? -and $Null -ne $Result)
+		{
+			$SysvolState  = $Result.State
+
+			#https://docs.microsoft.com/en-us/troubleshoot/windows-server/networking/troubleshoot-missing-sysvol-and-netlogon-shares
+			#The state values can be any of:
+			#0 = Uninitialized
+			#1 = Initialized
+			#2 = Initial Sync
+			#3 = Auto Recovery
+			#4 = Normal
+			#5 = In Error
+
+			Switch($Result.State)
+			{
+				0		{$SysvolState  = "0 = Uninitialized"; Break}
+				1		{$SysvolState  = "1 = Initialized"; Break}
+				2		{$SysvolState  = "2 = Initial Sync"; Break}
+				3		{$SysvolState  = "3 = Auto Recovery"; Break}
+				4		{$SysvolState  = "4 = Normal"; Break}
+				5		{$SysvolState  = "5 = In Error"; Break}
+				Default {$SysvolState  = "Unable to determine the SYSVOL State: $($Result.State)"; Break}
+			}
+		}
+		Else
+		{
+			$SysvolState  = "Unable to determine the SYSVOL State: $($Result.State)"
+		}
 	}
 
 	If( $DSADatabaseFile -and $DSADatabaseFile.Length -gt 0 )
@@ -11539,11 +11641,18 @@ Function OutputADFileLocations
 	{
 		WriteWordLine 3 0 "AD Database, Logfile and SYSVOL Locations"
 		[System.Collections.Hashtable[]] $ScriptInformation = @()
+		$WordHighlightedCells = New-Object System.Collections.ArrayList
+		[int] $CurrentServiceIndex = 5
 		
 		$Scriptinformation += @{ Data = "HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters\DSA Database file"; Value = $DSADatabaseFile; }
 		$Scriptinformation += @{ Data = "DSA Database file size "; Value = "$($DSADatabaseFileSize) GB"; }
 		$Scriptinformation += @{ Data = "HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters\Database log files path"; Value = $DatabaseLogFilesPath; }
-		$Scriptinformation += @{ Data = "HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters\SysVol"; Value = $SysVol; }
+		$Scriptinformation += @{ Data = "HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters\SysVol"; Value = $Sysvol; }
+		$Scriptinformation += @{ Data = "SYSVOL State"; Value = $SysvolState; }
+		If($SysvolState -NotLike "4 = Normal")
+		{
+			$WordHighlightedCells.Add(@{ Row = $CurrentServiceIndex; Column = 2; }) > $Null
+		}
 		
 		$Table = AddWordTable -Hashtable $ScriptInformation `
 		-Columns Data,Value `
@@ -11553,6 +11662,10 @@ Function OutputADFileLocations
 
 		SetWordCellFormat -Collection $Table -Size 9 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15
+		If($WordHighlightedCells.Count -gt 0)
+		{
+			SetWordCellFormat -Coordinates $WordHighlightedCells -Table $Table -Bold -BackgroundColor $wdColorRed -Solid;
+		}
 
 		$Table.Columns.Item(1).Width = 350
 		$Table.Columns.Item(2).Width = 130
@@ -11572,6 +11685,14 @@ Function OutputADFileLocations
 		Line 2 "DSA Database file size`t`t`t: $($DSADatabaseFileSize) GB"
 		Line 2 "NTDS\Parameters\Database log files path`t: " $DatabaseLogFilesPath
 		Line 2 "Netlogon\Parameters\SysVol`t`t: " $SysVol
+		If($SysvolState -NotLike "4 = Normal")
+		{
+			Line 2 "SYSVOL State`t`t`t`t: " "***$($SysvolState)***"
+		}
+		Else
+		{
+			Line 2 "SYSVOL State`t`t`t`t: " $SysvolState
+		}
 		Line 0 ""
 	}
 	If($HTML)
@@ -11579,30 +11700,25 @@ Function OutputADFileLocations
 		WriteHTMLLine 3 0 'AD Database, Logfile and SYSVOL Locations'
 
 		#V3.00 pre-allocate rowdata
-		$rowdata = New-Object System.Array[] 3
+		$rowdata = New-Object System.Array[] 4
 
-		$rowdata[ 0 ] = @(
-			'DSA Database file size',  $htmlsb,
-			"$DSADatabaseFileSize GB", $htmlwhite
-		)
+		$columnHeaders = @('HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters\DSA Database file',$htmlsb,$DSADatabaseFile,$htmlwhite)
+		$rowdata[ 0 ] = @('DSA Database file size',$htmlsb,"$DSADatabaseFileSize GB",$htmlwhite)
+		$rowdata[ 1 ] = @('HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters\Database log files path',$htmlsb,$DatabaseLogFilesPath,$htmlwhite)
+		$rowdata[ 2 ] = @('HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters\SysVol',$htmlsb,$SysVol,$htmlwhite)
+		If($SysvolState -NotLike "4 = Normal")
+		{
+			$HTMLHighlightedCells = $htmlred
+		}
+		Else
+		{
+			$HTMLHighlightedCells = $htmlwhite
+		} 
+		$rowdata[ 3 ] = @('SYSVOL State',$htmlsb,$SysvolState,$HTMLHighlightedCells)
 
-		$rowdata[ 1 ] = @(
-			'HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters\Database log files path', $htmlsb,
-			$DatabaseLogFilesPath,                                                             $htmlwhite
-		)
+		$columnWidths  = @( '500', '150' )
 
-		$rowdata[ 2 ] = @(
-			'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters\SysVol', $htmlsb,
-			$SysVol,                                                              $htmlwhite
-		)
-
-		$columnWidths  = @( '600px', '150px' )
-		$columnHeaders = @(
-			'HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters\DSA Database file', $htmlsb,
-			$DSADatabaseFile,                                                            $htmlwhite
-		)
-
-		FormatHTMLTable -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths -tablewidth '750'
+		FormatHTMLTable -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths -tablewidth '650'
 		WriteHTMLLine 0 0 ''
 
 		$rowData = $null
@@ -12037,7 +12153,10 @@ Function ProcessOrganizationalUnits
 
 			SetWordCellFormat -Collection $Table -Size 9 -BackgroundColor $wdColorWhite
 			SetWordCellFormat -Collection $Table.Rows.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
-			SetWordCellFormat -Coordinates $WordHighlightedCells -Table $Table -Bold -BackgroundColor $wdColorRed -Solid;
+			If($WordHighlightedCells.Count -gt 0)
+			{
+				SetWordCellFormat -Coordinates $WordHighlightedCells -Table $Table -Bold -BackgroundColor $wdColorRed -Solid;
+			}
 
 			$Table.Columns.Item(1).Width = 125
 			$Table.Columns.Item(2).Width = 100
@@ -12384,7 +12503,16 @@ Function ProcessGroupInformation
 			
 			Write-Verbose "$(Get-Date -Format G): `t`tListing domain admins"
 			$Admins = $Null
-			$Admins = @(Get-ADGroupMember -Identity $DomainAdminsSID -Server $Domain -EA 0)
+			
+			try
+			{
+				$Admins = @(Get-ADGroupMember -Identity $DomainAdminsSID -Server $Domain -EA 0)
+			}
+			
+			catch
+			{
+				#hide error
+			}
 			
 			If($? -and $Null -ne $Admins)
 			{
@@ -12446,7 +12574,7 @@ Function ProcessGroupInformation
 						$xRow++
 					}
 					
-					#V3.01 change to use same methos as EA & SA
+					#V3.01 change to use same method as EA & SA
 					$dn = $Admin.distinguishedName
 					$xServer = $dn.SubString( $dn.IndexOf( ',DC=' ) + 1 ).Replace( 'DC=', '' ).Replace( ',', '.' )
 
@@ -12576,12 +12704,39 @@ Function ProcessGroupInformation
 					
 					If($HTML)
 					{
+						If($PasswordLastSet -eq "No Date Set")
+						{
+							$HTMLHighlightedCells1 = $htmlred
+						}
+						Else
+						{
+							$HTMLHighlightedCells1 = $htmlwhite
+						}
+						
+						If($PasswordNeverExpires -eq "True")
+						{
+							$HTMLHighlightedCells2 = $htmlred
+						}
+						Else
+						{
+							$HTMLHighlightedCells2 = $htmlwhite
+						}
+						
+						If($Enabled -eq "False")
+						{
+							$HTMLHighlightedCells3 = $htmlred
+						}
+						Else
+						{
+							$HTMLHighlightedCells3 = $htmlwhite
+						}
+						
 						$rowdata[ $rowIndx ] = @(
 							$UserName,             $htmlwhite,
 							$Domain,               $htmlwhite,
-							$PasswordLastSet,      $htmlwhite,
-							$PasswordNeverExpires, $htmlwhite,
-							$Enabled,              $htmlwhite
+							$PasswordLastSet,      $HTMLHighlightedCells1,
+							$PasswordNeverExpires, $HTMLHighlightedCells2,
+							$Enabled,              $HTMLHighlightedCells3
 						)
 						$rowIndx++
 					}
@@ -12673,7 +12828,15 @@ Function ProcessGroupInformation
 			{
 				Write-Verbose "$(Get-Date -Format G): `t`tListing enterprise admins"
 			
-				$Admins = @(Get-ADGroupMember -Identity $EnterpriseAdminsSID -Server $Domain -EA 0)
+				try
+				{
+					$Admins = @(Get-ADGroupMember -Identity $EnterpriseAdminsSID -Server $Domain -EA 0)
+				}
+				
+				catch
+				{
+					#hide error
+				}
 				
 				If($? -and $Null -ne $Admins)
 				{
@@ -12862,12 +13025,39 @@ Function ProcessGroupInformation
 						
 						If($HTML)
 						{
+							If($PasswordLastSet -eq "No Date Set")
+							{
+								$HTMLHighlightedCells1 = $htmlred
+							}
+							Else
+							{
+								$HTMLHighlightedCells1 = $htmlwhite
+							}
+							
+							If($PasswordNeverExpires -eq "True")
+							{
+								$HTMLHighlightedCells2 = $htmlred
+							}
+							Else
+							{
+								$HTMLHighlightedCells2 = $htmlwhite
+							}
+							
+							If($Enabled -eq "False")
+							{
+								$HTMLHighlightedCells3 = $htmlred
+							}
+							Else
+							{
+								$HTMLHighlightedCells3 = $htmlwhite
+							}
+							
 							$rowdata[ $rowIndx ] = @(
 								$UserName,             $htmlwhite,
 								$Domain,               $htmlwhite,
-								$PasswordLastSet,      $htmlwhite,
-								$PasswordNeverExpires, $htmlwhite,
-								$Enabled,              $htmlwhite
+								$PasswordLastSet,      $HTMLHighlightedCells1,
+								$PasswordNeverExpires, $HTMLHighlightedCells2,
+								$Enabled,              $HTMLHighlightedCells3
 							)
 							$rowIndx++
 						}
@@ -12968,7 +13158,15 @@ Function ProcessGroupInformation
 			{
 				Write-Verbose "$(Get-Date -Format G): `t`tListing schema admins"
 			
-				$Admins = @(Get-ADGroupMember -Identity $SchemaAdminsSID -Server $Domain -EA 0)
+				try
+				{
+					$Admins = @(Get-ADGroupMember -Identity $SchemaAdminsSID -Server $Domain -EA 0)
+				}
+				
+				catch
+				{
+					#hide error
+				}
 				
 				If($? -and $Null -ne $Admins)
 				{
@@ -13151,12 +13349,39 @@ Function ProcessGroupInformation
 						}
 						If($HTML)
 						{
+							If($PasswordLastSet -eq "No Date Set")
+							{
+								$HTMLHighlightedCells1 = $htmlred
+							}
+							Else
+							{
+								$HTMLHighlightedCells1 = $htmlwhite
+							}
+							
+							If($PasswordNeverExpires -eq "True")
+							{
+								$HTMLHighlightedCells2 = $htmlred
+							}
+							Else
+							{
+								$HTMLHighlightedCells2 = $htmlwhite
+							}
+							
+							If($Enabled -eq "False")
+							{
+								$HTMLHighlightedCells3 = $htmlred
+							}
+							Else
+							{
+								$HTMLHighlightedCells3 = $htmlwhite
+							}
+							
 							$rowdata[ $rowIndx ] = @(
 								$UserName,             $htmlwhite,
 								$Domain,               $htmlwhite,
-								$PasswordLastSet,      $htmlwhite,
-								$PasswordNeverExpires, $htmlwhite,
-								$Enabled,              $htmlwhite
+								$PasswordLastSet,      $HTMLHighlightedCells1,
+								$PasswordNeverExpires, $HTMLHighlightedCells2,
+								$Enabled,              $HTMLHighlightedCells3
 							)
 							$rowIndx++
 						}
@@ -13400,11 +13625,38 @@ Function ProcessGroupInformation
 					}
 					If($HTML)
 					{
+						If($PasswordLastSet -eq "No Date Set")
+						{
+							$HTMLHighlightedCells1 = $htmlred
+						}
+						Else
+						{
+							$HTMLHighlightedCells1 = $htmlwhite
+						}
+						
+						If($PasswordNeverExpires -eq "True")
+						{
+							$HTMLHighlightedCells2 = $htmlred
+						}
+						Else
+						{
+							$HTMLHighlightedCells2 = $htmlwhite
+						}
+						
+						If($Enabled -eq "False")
+						{
+							$HTMLHighlightedCells3 = $htmlred
+						}
+						Else
+						{
+							$HTMLHighlightedCells3 = $htmlwhite
+						}
+						
 						$rowdata[ $rowIndx ] = @(
 							$UserName,             $htmlwhite,
-							$PasswordLastSet,      $htmlwhite,
-							$PasswordNeverExpires, $htmlwhite,
-							$Enabled,              $htmlwhite
+							$PasswordLastSet,      $HTMLHighlightedCells1,
+							$PasswordNeverExpires, $HTMLHighlightedCells2,
+							$Enabled,              $HTMLHighlightedCells3
 						)
 						$rowIndx++
 					}
@@ -13495,7 +13747,9 @@ Function ProcessGroupInformation
 			}
 			
 			Write-Verbose "$(Get-Date -Format G): `t`tListing groups with AdminCount=1"
-			$AdminCounts = @(Get-ADGroup -LDAPFilter "(admincount=1)" -Server $Domain -EA 0 | Select-Object Name)
+			#$AdminCounts = @(Get-ADGroup -LDAPFilter "(admincount=1)" -Server $Domain -EA 0 | Select-Object Name)
+			#Fix in 3.03 where the group name doesn’t match the samAccountName or the distinguishedName
+			$AdminCounts = @(Get-ADGroup -LDAPFilter "(admincount=1)" -Server $Domain -EA 0 | Select-Object Name, distinguishedName)
 			
 			If($? -and $Null -ne $AdminCounts)
 			{
@@ -13541,7 +13795,20 @@ Function ProcessGroupInformation
 						$xRow++
 					}
 					
-					[array]$Members = @(Get-ADGroupMember -Identity $Admin.Name -Server $Domain -EA 0 | Sort-Object Name)
+					#Fix in 3.03 where the group name doesn’t match the samAccountName or the distinguishedName
+					#[array]$Members = @(Get-ADGroupMember -Identity $Admin.Name -Server $Domain -EA 0 | Sort-Object Name)
+					
+					try
+					{
+						[array]$Members = @(Get-ADGroupMember -Identity $Admin.distinguishedName -Server $Domain -EA 0 | Sort-Object Name)
+						$GroupError = $False
+					}
+					
+					catch
+					{
+						#hide error from console
+						$GroupError = $True
+					}
 					
 					If($? -and $Null -ne $Members)
 					{
@@ -13557,42 +13824,59 @@ Function ProcessGroupInformation
 					If($MSWord -or $PDF)
 					{
 						$Table.Cell($xRow,1).Range.Text = "$($Admin.Name) ($($MembersCountStr) members)"
-						$MbrStr = ""
-						If($MembersCount -gt 0)
+						If($GroupError)
 						{
-							ForEach($Member in $Members)
+							$Table.Cell($xRow,2).Shading.BackgroundPatternColor = $wdColorRed
+							$Table.Cell($xRow,2).Range.Font.Bold  = $True
+							$Table.Cell($xRow,2).Range.Font.Color = $WDColorBlack
+							$Table.Cell($xRow,2).Range.Text       = "Unable to retrieve group members. Check for orphaned SIDs."
+						}
+						Else
+						{
+							$MbrStr = ""
+							If($MembersCount -gt 0)
 							{
-								$MbrStr += "$($Member.Name)`r"
+								ForEach($Member in $Members)
+								{
+									$MbrStr += "$($Member.Name)`r"
+								}
+								$Table.Cell($xRow,2).Range.Text = $MbrStr
 							}
-							$Table.Cell($xRow,2).Range.Text = $MbrStr
 						}
 					}
 					If($Text)
 					{
 						[string]$MembersCountStr = "{0:N0}" -f $MembersCount
 						Line 2 "Group Name`t: $($Admin.Name) ($($MembersCountStr) members)"
-						$MbrStr = ""
-						If($MembersCount -gt 0)
+						If($GroupError)
 						{
-							Line 2 "Members`t`t: " -NoNewLine
-							$cnt = 0
-							ForEach($Member in $Members)
-							{
-								$cnt++
-								
-								If($cnt -eq 1)
-								{
-									Line 0 $Member.Name
-								}
-								Else
-								{
-									Line 4 "  $($Member.Name)"
-								}
-							}
+							Line 2 "Members`t`t: ***Unable to retrieve group members. Check for orphaned SIDs.***"
 						}
 						Else
 						{
-							Line 2 "Members`t`t: None"
+							$MbrStr = ""
+							If($MembersCount -gt 0)
+							{
+								Line 2 "Members`t`t: " -NoNewLine
+								$cnt = 0
+								ForEach($Member in $Members)
+								{
+									$cnt++
+									
+									If($cnt -eq 1)
+									{
+										Line 0 $Member.Name
+									}
+									Else
+									{
+										Line 4 "  $($Member.Name)"
+									}
+								}
+							}
+							Else
+							{
+								Line 2 "Members`t`t: None"
+							}
 						}
 						Line 0 ""
 					}
@@ -13600,24 +13884,35 @@ Function ProcessGroupInformation
 					{
 						[string]$MembersCountStr = "{0:N0}" -f $MembersCount
 						$GroupName = "$($Admin.Name) ($($MembersCountStr) members)"
-						If($MembersCount -gt 0)
+						If($GroupError)
 						{
-							$first = $GroupName
-							ForEach($Member in $Members)
-							{
-								$rowdata += @(, (
-									$first,       $htmlwhite,
-									$Member.Name, $htmlwhite
-								) )
-								$first = ''
-							}
+							$MbrStr = "Unable to retrieve group members. Check for orphaned SIDs."
+							$rowdata += @(, (
+								$GroupName, $htmlwhite,
+								$MbrStr, $htmlred
+							) )
 						}
 						Else
 						{
-							$rowdata += @(, (
-								$GroupName, $htmlwhite,
-								'empty',  $htmlwhite
-							) )
+							If($MembersCount -gt 0)
+							{
+								$first = $GroupName
+								ForEach($Member in $Members)
+								{
+									$rowdata += @(, (
+										$first,       $htmlwhite,
+										$Member.Name, $htmlwhite
+									) )
+									$first = ''
+								}
+							}
+							Else
+							{
+								$rowdata += @(, (
+									$GroupName, $htmlwhite,
+									'empty',  $htmlwhite
+								) )
+							}
 						}
 					}
 				}
@@ -14546,6 +14841,8 @@ Function getDSUsers
     )
 
 	[Int64] $script:MaxPasswordAge = $null
+
+
 	[Object] $domainADSI = $null
 
 	Function GetMaximumPasswordAge
@@ -14569,14 +14866,31 @@ Function getDSUsers
 		### Using ConvertLargeIntegerToInt64 takes the COM object and converts 
 		### it into a native .Net type.
 
-		[Int64] $script:MaxPasswordAge = $domainADSI.ConvertLargeIntegerToInt64( $domainADSI.maxPwdAge.Value )
+		#[Int64] $script:MaxPasswordAge = $domainADSI.ConvertLargeIntegerToInt64( $domainADSI.maxPwdAge.Value )
 
 		### Convert to days
 		### 	there are 86,400 seconds per day (24 * 60 * 60)
-		### 	there are 10,000,000 nanoseconds per second
+		### there are 10,000,00 100 nanosecond units per second
+		### https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime
+
+		#Update for 3.03 from MBS
 
 		[Int64] $script:MaxPasswordAge = ( -$MaxPasswordAge / ( 86400 * 10000000 ) )
+		
+		If( $script:MaxPasswordAge -eq [Int64]::MinValue )
+		{
+			### there is no defined maximum password age group policy
+			$script:MaxPasswordAge = -1
+		}
+		Else
+		{
+			### Convert to days
+			###     there are 86,400 seconds per day (24 * 60 * 60)
+			###     there are 10,000,000 100 nanosecond units per second
+			### https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime
 
+			[Int64] $script:MaxPasswordAge = ( -$MaxPasswordAge / ( 86400 * 10000000 ) )
+		}
 		Return $MaxPasswordAge
 	}
 
@@ -14701,6 +15015,7 @@ Function getDSUsers
     $ctHomeDrive                  = 0
     $ctPrimaryGroup               = 0
     $ctRDSHomeDrive               = 0
+	$ctOrphanedFSPs               = 0
 
     $ctActiveUsers                = 0
     $ctActivePasswordExpired      = 0
@@ -14722,6 +15037,7 @@ Function getDSUsers
     $listHomeDrive            = New-Object System.Collections.Generic.List[PsCustomObject]
     $listPrimaryGroup         = New-Object System.Collections.Generic.List[PsCustomObject]
     $listRDSHomeDrive         = New-Object System.Collections.Generic.List[PsCustomObject]
+    $listOrphanedFSPs         = New-Object System.Collections.Generic.List[PsCustomObject]
 
 ##$global:colResults = $colresults
 
@@ -14807,7 +15123,7 @@ Function getDSUsers
 			{
 				$passwordExpired = $true
 			}
-			Else
+			ElseIf( $script:MaxPasswordAge -ge 0 )
 			{
 				$pls = If( $null -ne ( $obj = $objResult.Properties[ 'pwdlastset' ] ) -and $obj.Count -gt 0 ) 
 					{ $obj.Item( 0 ) } Else { $null }
@@ -14987,6 +15303,42 @@ Function getDSUsers
     }
 
     Write-Verbose "$(Get-Date -Format G): `t`tGetDSUsers main processing done"
+	
+	#FSP added in 3.03
+    Write-Verbose "$(Get-Date -Format G): `t`tProcessing Orphaned Foreign Security Principals"
+	
+	#https://powershell.org/forums/topic/foreign-security-principals/
+
+	# Get a list of FSPs
+	$results = Get-ADObject -Filter { objectClass -eq "foreignSecurityPrincipal" } -Properties memberof | Sort-Object Name
+	ForEach($result in $results)
+	{
+		
+		$TranslatedName = $null
+		try 
+		{
+			$TranslatedName = ([System.Security.Principal.SecurityIdentifier] $result.Name).Translate([System.Security.Principal.NTAccount])
+		}
+		catch 
+		{
+			$TranslatedName = "Orphaned"
+			
+			#only need the orphans
+			$FSPGroups = ""
+			ForEach($Group in $Result.MemberOf)
+			{
+				$FSPGroups += $Group
+			}
+			$obj = [PSCustomObject] @{
+				Name           = $Result.Name
+				TranslatedName = $TranslatedName
+				Groups         = $FSPGroups
+			}
+			$listOrphanedFSPs.Add($obj) > $Null
+		}
+	}
+
+	$ctOrphanedFSPs = $listOrphanedFSPs.Count
 
     <#
 	Write-Verbose "$(Get-Date -Format G): ctUsers                $ctUsers"
@@ -15035,6 +15387,7 @@ Function getDSUsers
     [String] $strHomeDrive                  = $fs -f $ctHomeDrive
     [String] $strPrimaryGroup               = $fs -f $ctPrimaryGroup
     [String] $strRDSHomeDrive               = $fs -f $ctRDSHomeDrive
+    [String] $strOrphanedFSPs               = $fs -f $ctOrphanedFSPs
 
     [String] $strActiveUsers                = $fs -f $ctActiveUsers
     [String] $strActivePasswordExpired      = $fs -f $ctActivePasswordExpired
@@ -15072,19 +15425,20 @@ Function getDSUsers
     If( $Text )
     {
         lx 0 'All Users'
-        lx 1 'Total Users                 ' $strUsers
-        lx 1 'Who are unknown*            ' $strUsersUnknown         ', ' $pctUsersUnknown
-        lx 1 'Who are disabled            ' $strUsersDisabled        ', ' $pctUsersDisabled
-        lx 1 'Who are locked out          ' $strUsersLockedOut       ', ' $pctUsersLockedOut
-        lx 1 'With password expired       ' $strPasswordExpired      ', ' $pctPasswordExpired
-        lx 1 'With password never expires ' $strPasswordNeverExpires ', ' $pctPasswordNeverExpires
-        lx 1 'With password not required  ' $strPasswordNotRequired  ', ' $pctPasswordNotRequired
-        lx 1 'Who cannot change password  ' $strCannotChangePassword ', ' $pctCannotChangePassword
-        lx 1 'Who have never logged on    ' $strNolastLogonTimestamp ', ' $pctNolastLogonTimestamp
-        lx 1 'Who have SID history        ' $strHasSIDHistory        ', ' $pctHasSIDHistory
-        lx 1 'Who have a homedrive        ' $strHomeDrive            ', ' $pctHomeDrive
-        lx 1 'Who have a primary group    ' $strPrimaryGroup         ', ' $pctPrimaryGroup
-        lx 1 'Who have a RDS homedrive    ' $strRDSHomeDrive         ', ' $pctRDSHomeDrive
+        lx 1 'Total Users                             ' $strUsers
+        lx 1 'Who are unknown*                        ' $strUsersUnknown         ', ' $pctUsersUnknown
+        lx 1 'Who are disabled                        ' $strUsersDisabled        ', ' $pctUsersDisabled
+        lx 1 'Who are locked out                      ' $strUsersLockedOut       ', ' $pctUsersLockedOut
+        lx 1 'With password expired                   ' $strPasswordExpired      ', ' $pctPasswordExpired
+        lx 1 'With password never expires             ' $strPasswordNeverExpires ', ' $pctPasswordNeverExpires
+        lx 1 'With password not required              ' $strPasswordNotRequired  ', ' $pctPasswordNotRequired
+        lx 1 'Who cannot change password              ' $strCannotChangePassword ', ' $pctCannotChangePassword
+        lx 1 'Who have never logged on                ' $strNolastLogonTimestamp ', ' $pctNolastLogonTimestamp
+        lx 1 'Who have SID history                    ' $strHasSIDHistory        ', ' $pctHasSIDHistory
+        lx 1 'Who have a homedrive                    ' $strHomeDrive            ', ' $pctHomeDrive
+        lx 1 'Who have a primary group                ' $strPrimaryGroup         ', ' $pctPrimaryGroup
+        lx 1 'Who have a RDS homedrive                ' $strRDSHomeDrive         ', ' $pctRDSHomeDrive
+        lx 1 'Orphaned Foreign Security Principals    ' $strOrphanedFSPs         ', ' " N/A"
         lx 0
         lx 1 '* Unknown users are user accounts with no UserAccountControl property.'
         lx 1 '  This should not occur.'
@@ -15183,6 +15537,12 @@ Function getDSUsers
 			'Who have a RDS homedrive', $htmlsb,
 			$strRDSHomeDrive,           $htmlwhite,
 			$pctRDSHomeDrive,           $htmlwhite
+		)
+
+		$rowdata[ 11 ] = @(
+			'Orphaned Foreign Security Principals', $htmlsb,
+			 $strOrphanedFSPs,           $htmlwhite,
+			"N/A",           $htmlwhite
 		)
 
 		$columnWidths = @( '300px', '75px', '125px' )
@@ -15373,6 +15733,14 @@ Function getDSUsers
 		$Table.Cell(13,3).Range.ParagraphFormat.Alignment = $wdAlignParagraphRight
 		$Table.Cell(13,3).Range.Text = $pctRDSHomeDrive
 
+		$Table.Cell(14,1).Shading.BackgroundPatternColor = $wdColorGray15
+		$Table.Cell(14,1).Range.Font.Bold = $True
+		$Table.Cell(14,1).Range.Text = "Orphaned Foreign Security Principals"
+		$Table.Cell(14,2).Range.ParagraphFormat.Alignment = $wdAlignParagraphRight
+		$Table.Cell(14,2).Range.Text = $strOrphanedFSPs
+		$Table.Cell(14,3).Range.ParagraphFormat.Alignment = $wdAlignParagraphRight
+		$Table.Cell(14,3).Range.Text = "N/A"
+
 		$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustNone)
 		$Table.AutoFitBehavior($wdAutoFitContent)
 
@@ -15522,6 +15890,11 @@ Function getDSUsers
 		If($ctRDSHomeDrive -gt 0)
 		{
 			OutputRDSHDUserInfo $listRDSHomeDrive 'All users with RDS HomeDrive set in ADUC'
+		}
+
+		If($ctOrphanedFSPs -gt 0)
+		{
+			OutputFSPUserInfo $listOrphanedFSPs 'Orphaned Foreign Security Principals'
 		}
 
 	}
@@ -16075,6 +16448,105 @@ Function OutputRDSHDUserInfo
 		$rowdata = $null
 	}
 } ## end Function OutputRDSHDUserInfo
+
+Function OutputFSPUserInfo
+{
+	#new for 3.03
+	Param
+	(
+		[Object[]] $Users, 
+		[string] $title
+	)
+
+	Write-Verbose "$(Get-Date -Format G): `t`t`t`tOutput $($title)"
+	$Users = $Users | Sort-Object Name
+	
+	If( $Users -and $Users.Length -gt 0 )
+	{
+		$arrayLength = $Users.Length
+	}
+	Else
+	{
+		$arrayLength = 0
+	}
+
+	If($MSWORD -or $PDF)
+	{
+		[System.Collections.Hashtable[]] $UsersWordTable = @()
+
+		WriteWordLine 4 0 ( $title + ' (' + $arrayLength.ToString() + ')' )
+
+		ForEach($User in $Users)
+		{
+			$WordTableRowHash = @{
+				Name   = $User.Name; 
+				Groups = $User.Groups
+			}
+
+			## Add the hash to the array
+			$UsersWordTable += $WordTableRowHash
+		}
+		
+		## Add the table to the document, using the hashtable
+		$Table = AddWordTable -Hashtable $UsersWordTable `
+		-Columns Name, Groups `
+		-Headers "Name", "Groups" `
+		-Format $wdTableGrid `
+		-AutoFit $wdAutoFitFixed;
+
+		SetWordCellFormat -Collection $Table -Size 9 -BackgroundColor $wdColorWhite
+		SetWordCellFormat -Collection $Table.Rows.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+
+		$Table.Columns.Item(1).Width = 250;
+		$Table.Columns.Item(2).Width = 250;
+
+		$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustNone)
+
+		FindWordDocumentEnd
+		$Table = $Null
+		WriteWordLine 0 0 ""
+	}
+	If($Text)
+	{
+		Line 0 ( $title + ' (' + $arrayLength.ToString() + ')' )
+		Line 0 ""
+
+		ForEach($User in $Users)
+		{
+			Line 1 "Name`t: " $User.Name
+			Line 1 "Groups`t: " $User.Groups
+			Line 0 ""
+		}
+	}
+	If($HTML)
+	{
+		#V3.00 pre-allocate rowdata
+		## $rowdata = @()
+		WriteHTMLLine 4 0 ( $title + ' (' + $arrayLength.ToString() + ')' )
+		$rowdata  = New-Object System.Array[] $arrayLength
+		$rowIndex = 0
+		
+		ForEach($User in $Users)
+		{
+			$rowdata[ $rowIndex ] = @(
+				$User.Name,$htmlwhite,
+				$User.Groups,$htmlwhite
+			)
+			$rowIndex++
+		}
+
+		$columnWidths  = @( '400', '300')
+		$columnHeaders = @(
+			'Name',   $htmlsb,
+			'Groups', $htmlsb
+		)
+
+		FormatHTMLTable -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth '700'
+		WriteHTMLLine 0 0 ''
+
+		$rowdata = $null
+	}
+} ## end Function OutputFPSUserInfo
 #endregion
 
 #region DCDNSInfo
@@ -16776,7 +17248,7 @@ Function ProcessScriptEnd
 			}
 		}
 	}
-	$ErrorActionPreference = $SaveEAPreference
+	#$ErrorActionPreference = $SaveEAPreference
 }
 #endregion
 

--- a/ADDS_Inventory_V3_ReadMe.rtf
+++ b/ADDS_Inventory_V3_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -91,12 +91,12 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \rsid2974686\rsid3342358\rsid3477011\rsid3828116\rsid3830441\rsid4281248\rsid4467197\rsid4483701\rsid4945864\rsid5315553\rsid5720771\rsid5767175\rsid5849890\rsid5904556\rsid6038932\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7681868\rsid7695940
 \rsid8013811\rsid8220290\rsid8793422\rsid9243658\rsid9252303\rsid9512169\rsid9727541\rsid9838801\rsid9848053\rsid10101060\rsid10290913\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11433897\rsid11488686\rsid11602030\rsid12197314
 \rsid12322737\rsid12343757\rsid12588820\rsid12675704\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13511313\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14176547\rsid14566444\rsid14697282\rsid14893653\rsid14952143
-\rsid15166704\rsid15355254\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}
-{\revtim\yr2021\mo2\dy18\hr7\min22}{\version57}{\edmins652}{\nofpages23}{\nofwords6818}{\nofchars38864}{\nofcharsws45591}{\vern17}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\rsid15166704\rsid15355254\rsid15760967\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}
+{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo2\dy20\hr7\min21}{\version58}{\edmins670}{\nofpages23}{\nofwords6815}{\nofchars38851}{\nofcharsws45575}{\vern17}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
 \paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwNKwFABiP35stAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwNKoFANvc8rAtAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -273,19 +273,19 @@ t one Windows 7 SP1 or later computer with the Remote Server Administration Tool
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 
 HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100630065003500
-65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab000349}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab00034932}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 R\hich\af37\dbch\af31505\loch\f37 SAT for Windows 8 is available here, }
 {\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab000388}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab00038800}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030049}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -293,23 +293,23 @@ HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12916989 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c000000650000000302000600}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c00000065000000030200060057}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid13858952 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952\charrsid13858952 
 
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
-\par \hich\af37\dbch\af31505\loch\f37 Th}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12322737 \hich\af37\dbch\af31505\loch\f37 e V3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 
- script was developed using Windows Server 20}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12322737 \hich\af37\dbch\af31505\loch\f37 6 and 2019 }{
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 domain controllers and PowerShell Version }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 5}{\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 .0. The script was run on several Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 10}{\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37  computers with RSAT}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37  and }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 Word 201}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12322737 
-\hich\af37\dbch\af31505\loch\f37  and 2016}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5849890 \hich\af37\dbch\af31505\loch\f37  The script }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid12322737 \hich\af37\dbch\af31505\loch\f37 r}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5849890 \hich\af37\dbch\af31505\loch\f37 equires PowerShell V3 or later.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
-
+\par \hich\af37\dbch\af31505\loch\f37 Th}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12322737 \hich\af37\dbch\af31505\loch\f37 e V3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37  scrip
+\hich\af37\dbch\af31505\loch\f37 t was developed using Windows Server 20}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12322737 
+\hich\af37\dbch\af31505\loch\f37 6 and 2019 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 domain controllers and PowerShell Version }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 
+\hich\af37\dbch\af31505\loch\f37 5}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 .0. The script was run on several Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 
+\hich\af37\dbch\af31505\loch\f37 10}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37  computers with RSAT}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37  and }
+{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 Word 201}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid12322737 \hich\af37\dbch\af31505\loch\f37  and 2016}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5849890 \hich\af37\dbch\af31505\loch\f37  The script }{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12322737 \hich\af37\dbch\af31505\loch\f37 r}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5849890 \hich\af37\dbch\af31505\loch\f37 equires PowerShell V3 or later.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid10290913 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Script Usage
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 How to use\hich\af37\dbch\af31505\loch\f37  this script?
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 How to use this \hich\af37\dbch\af31505\loch\f37 script?
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Save the script as }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 ADDS}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
@@ -365,7 +365,7 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par }\pard\plain \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10945524 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
 \ltrch\fcs0 \insrsid10945524 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     C:\\\hich\af2\dbch\af31505\loch\f2 webster\\ADDS_Inventory_V3.ps1
+\par \hich\af2\dbch\af31505\loch\f2     C:\\webster\\ADDS_Inventory_V3.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
 \par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft Active Directory Forest.
@@ -373,30 +373,29 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
 \par \hich\af2\dbch\af31505\loch\f2     C:\\webster\\ADDS_Inventory_V3.ps1 [-ADDomain <String>] [-ADForest <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-MaxDetails] [-HTML] [-T\hich\af2\dbch\af31505\loch\f2 
-ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 <String>] [-Log] [-ScriptInfo] [-DCDNSInfo] [-GPOInheritance] [-Hardware] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-MaxDetails] [-HTML] [-Text] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 <String>] [-Log] [-ScriptInfo] [-DCDNSInfo] [-GPOInheritance] [-Hardware] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-IncludeUserInfo] [-Section <String[]>] [-Services] [-MSWord] [-PDF] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyEmail <String>] [-Company\hich\af2\dbch\af31505\loch\f2 Fax <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553 
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String\hich\af2\dbch\af31505\loch\f2 
+>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 <String>] [-SmtpPort <Int32>] [-SmtpServer <String>] [-SuperVerbose] [-From <String>] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5315553 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-To <String>] [-UseSSL] [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft Active Directory Forest using Microsoft
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a M\hich\af2\dbch\af31505\loch\f2 icrosoft Active Directory Forest using Microsoft
 \par \hich\af2\dbch\af31505\loch\f2     PowerShell, Word, plain text, or HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Word or PDF document, text, or HTML file named after the Active Directory
 \par \hich\af2\dbch\af31505\loch\f2     Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Version 3.0 change\hich\af2\dbch\af31505\loch\f2 s the default output report from Word to HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Version 3.0 changes the default output report from Word to\hich\af2\dbch\af31505\loch\f2  HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF document includes a Cover Page, Table of Contents}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2  and Footer.
@@ -416,21 +415,21 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script requires at least PowerShell version 3 but runs best in version 5.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Word is \hich\af2\dbch\af31505\loch\f2 NOT needed to run the script. This script \hich\af2\dbch\af31505\loch\f2 output}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  in Text and HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script out\hich\af2\dbch\af31505\loch\f2 put}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  in Text and HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a domain controller. This script was developed
 \par \hich\af2\dbch\af31505\loch\f2     and run from a Windows 10 VM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     While most of the script can be run with a non-admin ac\hich\af2\dbch\af31505\loch\f2 count, there are some features
+\par \hich\af2\dbch\af31505\loch\f2     While most of the script can \hich\af2\dbch\af31505\loch\f2 run with a non-admin account, there are some features
 \par \hich\af2\dbch\af31505\loch\f2     that will not or may not work without domain admin or enterprise admin rights.
 \par \hich\af2\dbch\af31505\loch\f2     The Hardware and Services parameters require domain admin privileges.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script \hich\af2\dbch\af31505\loch\f2 gather}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 information on }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\hich\af2\dbch\af31505\loch\f2 Time Server and AD \hich\af2\dbch\af31505\loch\f2 database, log file, and
+\par \hich\af2\dbch\af31505\loch\f2     The \hich\af2\dbch\af31505\loch\f2 script gather}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2  information on }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+Time Server and AD database, log file, and
 \par \hich\af2\dbch\af31505\loch\f2     SYSVOL locations. Those require access to the registry on each domain controller, which
-\par \hich\af2\dbch\af31505\loch\f2     means the script should now always be run from an elevated PowerShell session with an
+\par \hich\af2\dbch\af31505\loch\f2     means the script should now always be run from an elevated PowerShell session with \hich\af2\dbch\af31505\loch\f2 an
 \par \hich\af2\dbch\af31505\loch\f2     account with a minimum of domain admin rights.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Running the script in a forest with multiple domains requires Enterprise Admin rights.
@@ -445,77 +444,81 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100630065003500
-65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 
+65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab00030026}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebst\hich\af2\dbch\af31505\loch\f2 er.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab00030038}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8.1
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https\hich\af2\dbch\af31505\loch\f2 
-://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.\hich\af2\dbch\af31505\loch\f2 
+sharefile.com/d-s37209afb73dc48f497745924ed854226" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003c4}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s37209afb73dc4\hich\af2\dbch\af31505\loch\f2 8f497745924ed854226}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003c432}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed\hich\af2\dbch\af31505\loch\f2 854226}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 10
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030030}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
 \par \hich\af2\dbch\af31505\loch\f2     -ADDomain <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory domain object by providing one of the following
-\par \hich\af2\dbch\af31505\loch\f2         property values. The id\hich\af2\dbch\af31505\loch\f2 entifier in parentheses is the LDAP display name for the
+\par \hich\af2\dbch\af31505\loch\f2         property values. The identifier in p\hich\af2\dbch\af31505\loch\f2 arentheses is the LDAP display name for the
 \par \hich\af2\dbch\af31505\loch\f2         attribute. All values are for the domainDNS object that represents the domain.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Distinguished Name
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Example: DC=tullahoma,DC=corp,DC=labaddomain,DC=com
+\par \hich\af2\dbch\af31505\loch\f2         Example: \hich\af2\dbch\af31505\loch\f2 DC=labaddomain,DC=com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         GUID (objectGUID)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Example: b9fa5fbd-4334-4a98-85f1-3a3a44069fc6
+\par \hich\af2\dbch\af31505\loch\f2         Example: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967\charrsid15760967 \hich\af2\dbch\af31505\loch\f2 b147a813-9938-4a89-bc93-58a0d36c41c3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Security Identifier (objectSid)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Example: S-1-5-21-3643273344-1505409314-3732760578
+\par \hich\af2\dbch\af31505\loch\f2         Example: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967\charrsid15760967 \hich\af2\dbch\af31505\loch\f2 S-1-5-21-3916992870-515249095-1421388220}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         DNS domain name
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Example: tullahoma.corp.labaddomain.com
+\par \hich\af2\dbch\af31505\loch\f2         Example: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 \hich\af2\dbch\af31505\loch\f2 l}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+abaddomain.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         NetBIOS domain name
+\par \hich\af2\dbch\af31505\loch\f2         NetBIOS domain nam\hich\af2\dbch\af31505\loch\f2 e
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Example: Tullahoma
+\par \hich\af2\dbch\af31505\loch\f2         Example: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 \hich\af2\dbch\af31505\loch\f2 labaddomain}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If both ADForest and ADDomain are specified, ADDomain takes precedence.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?      \hich\af2\dbch\af31505\loch\f2  false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ADForest <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory forest object by providing one of the following
 \par \hich\af2\dbch\af31505\loch\f2         attribute values.
-\par \hich\af2\dbch\af31505\loch\f2         The identifier in parentheses is th\hich\af2\dbch\af31505\loch\f2 e LDAP display name for the attribute.
+\par \hich\af2\dbch\af31505\loch\f2         The identifier in parentheses is the LDAP display name for the\hich\af2\dbch\af31505\loch\f2  attribute.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Fully qualified domain name
 \par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2         GUID (objectGUID)
-\par \hich\af2\dbch\af31505\loch\f2                 Example: 599c3d2e-e61e-4d20-7b77-030d99495e19
+\par \hich\af2\dbch\af31505\loch\f2                 Example: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967\charrsid15760967 \hich\af2\dbch\af31505\loch\f2 b147a813-9938-4a89-bc93-58a0d36c41c3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 
 \par \hich\af2\dbch\af31505\loch\f2         DNS host name
 \par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2         NetBIOS name
@@ -523,26 +526,26 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Default value is $Env:USERDNSDOMAIN
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         If both ADForest an\hich\af2\dbch\af31505\loch\f2 d ADDomain are specified, ADDomain takes precedence.
+\par \hich\af2\dbch\af31505\loch\f2         If both ADForest and ADDomain are specified, ADDomain takes precedence.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?             \hich\af2\dbch\af31505\loch\f2        false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:USERDNSDOMAIN
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wi\hich\af2\dbch\af31505\loch\f2 ldcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ComputerName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies which domain controller to use to run the script against.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies which domain\hich\af2\dbch\af31505\loch\f2  controller to use to run the script against.
 \par \hich\af2\dbch\af31505\loch\f2         If ADForest is a trusted forest, then ComputerName is required to detect the
 \par \hich\af2\dbch\af31505\loch\f2         existence of ADForest.
-\par \hich\af2\dbch\af31505\loch\f2         Co\hich\af2\dbch\af31505\loch\f2 mputerName can be entered as the NetBIOS name, FQDN, localhost}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  or IP Address.
-\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and used.
+\par \hich\af2\dbch\af31505\loch\f2         ComputerName can be entered as the NetBIOS name, FQDN, localhost}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2  or IP Address.
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    If entered as localhost, the actual computer name is determined and used.
 \par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and use the actual
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 computer name.
+\par \hich\af2\dbch\af31505\loch\f2         computer name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ServerName.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is $Env:USERDNSDOMAIN
+\par \hich\af2\dbch\af31505\loch\f2         Default \hich\af2\dbch\af31505\loch\f2 value is $Env:USERDNSDOMAIN
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -553,23 +556,23 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2     -MaxDetails [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds maximum detail to the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is the same as using\hich\af2\dbch\af31505\loch\f2  the following parameters:
+\par \hich\af2\dbch\af31505\loch\f2         This is the same as using the following parameters:
 \par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo
 \par \hich\af2\dbch\af31505\loch\f2                 GPOInheritance
-\par \hich\af2\dbch\af31505\loch\f2                 Hardware
+\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  Hardware
 \par \hich\af2\dbch\af31505\loch\f2                 IncludeUserInfo
 \par \hich\af2\dbch\af31505\loch\f2                 Services
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extremely large report and
-\par \hich\af2\dbch\af31505\loch\f2         ca\hich\af2\dbch\af31505\loch\f2 n take a very long time to run.
+\par \hich\af2\dbch\af31505\loch\f2         can take a very long time to run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?    \hich\af2\dbch\af31505\loch\f2                 false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
@@ -579,26 +582,26 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    n\hich\af2\dbch\af31505\loch\f2 amed
+\par \hich\af2\dbch\af31505\loch\f2         Position?                  \hich\af2\dbch\af31505\loch\f2   named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is \hich\af2\dbch\af31505\loch\f2 disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [\hich\af2\dbch\af31505\loch\f2 <SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date timestamp to the end of the file name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The timestamp is\hich\af2\dbch\af31505\loch\f2  in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2         The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2         June 1, 2021 at 6PM is 2021-06-01_1800.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2021-06-01_1800.docx (or .pdf).
@@ -608,28 +611,28 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fa\hich\af2\dbch\af31505\loch\f2 lse
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
-\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at \hich\af2\dbch\af31505\loch\f2 the end of the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
-\par \hich\af2\dbch\af31505\loch\f2         The text\hich\af2\dbch\af31505\loch\f2  file is placed in the same folder from where the script \hich\af2\dbch\af31505\loch\f2 run}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
-\hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 .
+\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script run}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 .
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?    \hich\af2\dbch\af31505\loch\f2                 false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accep\hich\af2\dbch\af31505\loch\f2 t pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output fo\hich\af2\dbch\af31505\loch\f2 lder to save the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -640,24 +643,25 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?       \hich\af2\dbch\af31505\loch\f2              false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Outputs information \hich\af2\dbch\af31505\loch\f2 about the script to a text file.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 r}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 un}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 .
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 u\hich\af2\dbch\af31505\loch\f2 n}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 .
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input? \hich\af2\dbch\af31505\loch\f2       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -DCDNSInfo [<SwitchParameter>]
@@ -665,32 +669,32 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2         configured.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 to}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2  run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardwa\hich\af2\dbch\af31505\loch\f2 re information (i.e.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  Domain
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2  Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter \hich\af2\dbch\af31505\loch\f2 add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  an extra section to the report.
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2  an extra section to the report.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -GPOInheritance [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         In the Group Policies by OU section\hich\af2\dbch\af31505\loch\f2  adds Inherited GPOs in addition to the GPOs
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        directly linked.
+\par \hich\af2\dbch\af31505\loch\f2         In the Group Policies by OU section adds Inherited GPOs in addition to the GPOs
+\par \hich\af2\dbch\af31505\loch\f2         directly linked.
 \par \hich\af2\dbch\af31505\loch\f2         Adds a second column to the table GPO Type.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         T\hich\af2\dbch\af31505\loch\f2 his parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of GPO.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor, and
@@ -698,33 +702,33 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2         This parameter requires the script }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 to run}{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using a\hich\af2\dbch\af31505\loch\f2 n account with permission to retrieve hardware information (i.e.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  Domain
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2  Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2         Selecting this parameter \hich\af2\dbch\af31505\loch\f2 add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
-\hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  to both the time it takes to run the script and
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2         Selecting this parameter add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  to both the time it takes t\hich\af2\dbch\af31505\loch\f2 o run the script and
 \par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input\hich\af2\dbch\af31505\loch\f2 ?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -IncludeUserInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        For the User Miscellaneous Data section outputs a table with the SamAccountName
+\par \hich\af2\dbch\af31505\loch\f2         For the User Miscellaneous Data section outputs a table with the SamAccountName
 \par \hich\af2\dbch\af31505\loch\f2         and DistinguishedName of the users in the All Users counts:
 \par 
 \par \hich\af2\dbch\af31505\loch\f2                 Disabled users
 \par \hich\af2\dbch\af31505\loch\f2                 Unknown users
 \par \hich\af2\dbch\af31505\loch\f2                 Locked out users
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           All users with password expired
+\par \hich\af2\dbch\af31505\loch\f2                 All users with password expired
 \par \hich\af2\dbch\af31505\loch\f2                 All users whose password never expires
 \par \hich\af2\dbch\af31505\loch\f2                 All users with password not required
-\par \hich\af2\dbch\af31505\loch\f2                 All users who cannot change password
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           All users who cannot change password
 \par \hich\af2\dbch\af31505\loch\f2                 All users with SID History
 \par \hich\af2\dbch\af31505\loch\f2                 All users with Homedrive set in ADUC
 \par \hich\af2\dbch\af31505\loch\f2                 All users whose Primary Group is not Domain Users
@@ -732,28 +736,28 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 All Names in the ForeignSecurityPrincipals container that are orphan SIDs}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid5315553 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\par \hich\af2\dbch\af31505\loch\f2         The Text output option is li\hich\af2\dbch\af31505\loch\f2 mited to the first 25 characters of the SamAccountName
+\par \hich\af2\dbch\af31505\loch\f2         The Text output option is limited \hich\af2\dbch\af31505\loch\f2 to the first 25 characters of the SamAccountName
 \par \hich\af2\dbch\af31505\loch\f2         and the first 116 characters of the DistinguishedName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of IU.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         P\hich\af2\dbch\af31505\loch\f2 osition?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Section <String[]>
 \par \hich\af2\dbch\af31505\loch\f2         Processes one or more sections of the report.
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Valid options are:
+\par \hich\af2\dbch\af31505\loch\f2         Valid \hich\af2\dbch\af31505\loch\f2 options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Forest
 \par \hich\af2\dbch\af31505\loch\f2                 Sites
 \par \hich\af2\dbch\af31505\loch\f2                 Domains (includes Domain Controllers and optional Hardware, Services and
 \par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo)
 \par \hich\af2\dbch\af31505\loch\f2                 OUs (Organizational Units)
 \par \hich\af2\dbch\af31505\loch\f2                 Groups
-\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       GPOs
+\par \hich\af2\dbch\af31505\loch\f2                 \hich\af2\dbch\af31505\loch\f2 GPOs
 \par \hich\af2\dbch\af31505\loch\f2                 Misc (Miscellaneous data)
 \par \hich\af2\dbch\af31505\loch\f2                 All
 \par 
@@ -765,25 +769,25 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                All
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Services [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Gather information on all services running on domain controllers.
+\par \hich\af2\dbch\af31505\loch\f2         Gather information on all services running on domain controllers.
 \par \hich\af2\dbch\af31505\loch\f2         Servers that are configured to automatically start but are not running will be
 \par \hich\af2\dbch\af31505\loch\f2         colored in red.
-\par \hich\af2\dbch\af31505\loch\f2         Used on Domain Controllers only.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the sc\hich\af2\dbch\af31505\loch\f2 ript be run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Used on Domain Controllers only.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell session
 \par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve service information (i.e. Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
-\par \hich\af2\dbch\af31505\loch\f2         size of \hich\af2\dbch\af31505\loch\f2 the report.
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this param\hich\af2\dbch\af31505\loch\f2 eter will add to both the time it takes to run the script and
+\par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value           \hich\af2\dbch\af31505\loch\f2      False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
@@ -795,25 +799,25 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Sav\hich\af2\dbch\af31505\loch\f2 eAs PDF file instead of DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter uses Word's SaveAs PDF capability.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter uses Word's Sav\hich\af2\dbch\af31505\loch\f2 eAs PDF capability.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is d\hich\af2\dbch\af31505\loch\f2 isabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept \hich\af2\dbch\af31505\loch\f2 wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress\hich\af2\dbch\af31505\loch\f2  <String>
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
@@ -824,14 +828,14 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2          \hich\af2\dbch\af31505\loch\f2        Tiles (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
+\par \hich\af2\dbch\af31505\loch\f2         T\hich\af2\dbch\af31505\loch\f2 his parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -839,7 +843,7 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  The following Cover Pages have an Email field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
@@ -848,14 +852,14 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline \hich\af2\dbch\af31505\loch\f2 input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the C\hich\af2\dbch\af31505\loch\f2 over Page, if the Cover Page has the Fax field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word \hich\af2\dbch\af31505\loch\f2 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
@@ -863,41 +867,41 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
+\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
+\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
+\par \hich\af2\dbch\af31505\loch\f2         If either registry key do\hich\af2\dbch\af31505\loch\f2 es not exist and this parameter is not specified, the report
+\par \hich\af2\dbch\af31505\loch\f2         will not contain a Company Name on the cover page.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Posi\hich\af2\dbch\af31505\loch\f2 tion?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyName \hich\af2\dbch\af31505\loch\f2 <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
-\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
-\par \hich\af2\dbch\af31505\loch\f2         If either registry key does not exist and this parameter is not specified, the report
-\par \hich\af2\dbch\af31505\loch\f2         will not contain a Company Name on the cover page.
-\par \hich\af2\dbch\af31505\loch\f2         This par\hich\af2\dbch\af31505\loch\f2 ameter is only valid with the MSWORD and PDF output parameters.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fal\hich\af2\dbch\af31505\loch\f2 se
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page if the Cover Page has the Phone field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        The following Cover Pages have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input? \hich\af2\dbch\af31505\loch\f2       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
@@ -908,47 +912,47 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't\hich\af2\dbch\af31505\loch\f2  work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2\hich\af2\dbch\af31505\loch\f2 010/2013/2016. Doesn't work in 2013 or 2016, mostly
+\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
-\par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
+\par \hich\af2\dbch\af31505\loch\f2                 aft\hich\af2\dbch\af31505\loch\f2 er title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Conservative\hich\af2\dbch\af31505\loch\f2  (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if y\hich\af2\dbch\af31505\loch\f2 ou like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Wor\hich\af2\dbch\af31505\loch\f2 d 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font change\hich\af2\dbch\af31505\loch\f2 d to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (\hich\af2\dbch\af31505\loch\f2 Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 poin\hich\af2\dbch\af31505\loch\f2 t)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top d\hich\af2\dbch\af31505\loch\f2 ate is manually changed to
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
-\par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       resized or font changed to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Semaphor\hich\af2\dbch\af31505\loch\f2 e (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2                Stacks (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Tr\hich\af2\dbch\af31505\loch\f2 anscend (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. W\hich\af2\dbch\af31505\loch\f2 orks)
+\par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSW\hich\af2\dbch\af31505\loch\f2 ORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -956,17 +960,17 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
+\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:us\hich\af2\dbch\af31505\loch\f2 ername
+\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter\hich\af2\dbch\af31505\loch\f2  is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wi\hich\af2\dbch\af31505\loch\f2 ldcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port for the SmtpServer.
@@ -979,12 +983,12 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer\hich\af2\dbch\af31505\loch\f2  <String>
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report(s).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If From or To are used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -998,26 +1002,26 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -From <String>
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    -From <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or To are used, this is a\hich\af2\dbch\af31505\loch\f2  required parameter.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or To are used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the \hich\af2\dbch\af31505\loch\f2 username for the To email address.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or From are used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?       \hich\af2\dbch\af31505\loch\f2              false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fals\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
@@ -1027,46 +1031,47 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fa\hich\af2\dbch\af31505\loch\f2 lse
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
-\par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose,\hich\af2\dbch\af31505\loch\f2  Debug,
+\par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
+\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVaria\hich\af2\dbch\af31505\loch\f2 ble. For more information, see
 \par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 ).
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030033}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https:/go.micr\hich\af2\dbch\af31505\loch\f2 
+osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
-\par \hich\af2\dbch\af31505\loch\f2     No objects are output f\hich\af2\dbch\af31505\loch\f2 rom this script.  This script creates a Word or PDF document.
+\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a Word or PDF document.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: ADDS_Inventory_V3.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.02
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 \hich\af2\dbch\af31505\loch\f2 3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and Michael B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 February 18, 2021}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 February }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 \hich\af2\dbch\af31505\loch\f2 20}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 , 2021}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     --\hich\af2\dbch\af31505\loch\f2 ------------------------ EXAMPLE 1 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps\hich\af2\dbch\af31505\loch\f2 1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN\hich\af2\dbch\af31505\loch\f2 , then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that \hich\af2\dbch\af31505\loch\f2 as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
@@ -1075,14 +1080,14 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3\hich\af2\dbch\af31505\loch\f2 .ps1 -MSWord
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\C\hich\af2\dbch\af31505\loch\f2 ompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Admi\hich\af2\dbch\af31505\loch\f2 nistrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1091,7 +1096,7 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that \hich\af2\dbch\af31505\loch\f2 is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
@@ -1101,15 +1106,15 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -ADForest company.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain \hich\af2\dbch\af31505\loch\f2 controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}
-{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog se\hich\af2\dbch\af31505\loch\f2 rver and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
@@ -1118,7 +1123,7 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -ADDomain}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADDomain}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 child.company.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
@@ -1126,29 +1131,30 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2     child.company.tld for the AD Domain.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a globa\hich\af2\dbch\af31505\loch\f2 l catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}
-{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -----\hich\af2\dbch\af31505\loch\f2 --------------------- EXAMPLE 5 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest parent.company.tld -ADDomain
 \par \hich\af2\dbch\af31505\loch\f2     child.company.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Cre\hich\af2\dbch\af31505\loch\f2 ates an HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Because both ADForest and ADDomain are specified, ADDomain wins and child.company.tld
+\par \hich\af2\dbch\af31505\loch\f2     Because both ADForest and ADDomain are specified, ADDomai\hich\af2\dbch\af31505\loch\f2 n wins and child.company.tld
 \par \hich\af2\dbch\af31505\loch\f2     is used for AD Domain.
-\par \hich\af2\dbch\af31505\loch\f2     ADForest is set to the value of ADDomain.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 ADForest is set to the value of ADDomain.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the\hich\af2\dbch\af31505\loch\f2  script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
@@ -1156,31 +1162,32 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -ComputerName DC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -Compu\hich\af2\dbch\af31505\loch\f2 terName DC01
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_U\hich\af2\dbch\af31505\loch\f2 SER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\C\hich\af2\dbch\af31505\loch\f2 ompany="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline fo\hich\af2\dbch\af31505\loch\f2 r the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest
-\par \hich\af2\dbch\af31505\loch\f2     The script \hich\af2\dbch\af31505\loch\f2 run}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\hich\af2\dbch\af31505\loch\f2  remotely on the DC01 domain controller.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 The script run}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  remotely on the DC01 domain c\hich\af2\dbch\af31505\loch\f2 ontroller.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values and save}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
@@ -1190,13 +1197,13 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Car\hich\af2\dbch\af31505\loch\f2 l Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebst\hich\af2\dbch\af31505\loch\f2 er.com for the AD Forest.
+\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\par \hich\af2\dbch\af31505\loch\f2     a domain\hich\af2\dbch\af31505\loch\f2  controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
@@ -1204,20 +1211,21 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----------------\hich\af2\dbch\af31505\loch\f2 --------- EXAMPLE 8 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Text -ADForest corp.carlwebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values and save}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  the document as a formatted text file.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+ all default values and save}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+ the document as a formatted text file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
@@ -1231,22 +1239,23 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values and save}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  the document as an HTML file.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the \hich\af2\dbch\af31505\loch\f2 AD Forest.
+\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of \hich\af2\dbch\af31505\loch\f2 $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMP\hich\af2\dbch\af31505\loch\f2 LE 10 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -hardware
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\A\hich\af2\dbch\af31505\loch\f2 DDS_Inventory_V3.ps1 -hardware
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values and add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  additional information for each domain controller}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
@@ -1256,9 +1265,9 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to\hich\af2\dbch\af31505\loch\f2  the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
@@ -1268,34 +1277,37 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -services
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a\hich\af2\dbch\af31505\loch\f2 n HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values and add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  additional information for the services running}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 on }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 each }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 domain controller.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2  all default values and add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2  additional information for the services running}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 on }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 each \hich\af2\dbch\af31505\loch\f2 doma\hich\af2\dbch\af31505\loch\f2 in controller.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, \hich\af2\dbch\af31505\loch\f2 then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.\hich\af2\dbch\af31505\loch\f2 ps1 -DCDNSInfo
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -DCDNSInfo
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values and add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  additional information for each domain controller}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 about }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2  all default values and add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2  additional information for each domain controller}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 about }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 its DNS IP configuration.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     An extra section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 is}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
@@ -1303,10 +1315,10 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USER\hich\af2\dbch\af31505\loch\f2 DNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
@@ -1314,17 +1326,17 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage "Mod" -UserName "Carl We\hich\af2\dbch\af31505\loch\f2 bster" -ComputerName ADDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS\hich\af2\dbch\af31505\loch\f2 _Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster
+\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage "Mod" -UserName "Carl Webster" -ComputerName ADDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Mod for t\hich\af2\dbch\af31505\loch\f2 he Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $En\hich\af2\dbch\af31505\loch\f2 v:USERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Domain Controller named ADDC01 for the ComputerName.
 \par 
@@ -1333,22 +1345,22 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -MSWord -CN "Carl Webster Consulting"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CN "Carl Webster Consulting"
 \par \hich\af2\dbch\af31505\loch\f2     -CP "Mod" -UN "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
-\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias \hich\af2\dbch\af31505\loch\f2 CP).
+\par \hich\af2\dbch\af31505\loch\f2         Carl\hich\af2\dbch\af31505\loch\f2  Webster Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global cata\hich\af2\dbch\af31505\loch\f2 log server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}
-{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of \hich\af2\dbch\af31505\loch\f2 $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
@@ -1356,24 +1368,24 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2   
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2   
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 Street, London, England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
+\par \hich\af2\dbch\af31505\loch\f2     C\hich\af2\dbch\af31505\loch\f2 reates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Co\hich\af2\dbch\af31505\loch\f2 nsulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for th\hich\af2\dbch\af31505\loch\f2 e Company Phone.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       +44 1753 276600 for the Company Fax.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\par \hich\af2\dbch\af31505\loch\f2     a domain con\hich\af2\dbch\af31505\loch\f2 troller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
@@ -1398,10 +1410,10 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a \hich\af2\dbch\af31505\loch\f2 domain controller that is also a global catalog server and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 u}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 u}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
@@ -1409,16 +1421,16 @@ ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -AddDate\hich\af2\dbch\af31505\loch\f2 Time
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
@@ -1433,27 +1445,27 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all defau\hich\af2\dbch\af31505\loch\f2 lt values and save}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  the document as a PDF file.
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values and save}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  the document as a PDF file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Adm\hich\af2\dbch\af31505\loch\f2 inistrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURREN\hich\af2\dbch\af31505\loch\f2 T_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
+\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the \hich\af2\dbch\af31505\loch\f2 AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queri\hich\af2\dbch\af31505\loch\f2 es for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
@@ -1466,19 +1478,19 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------\hich\af2\dbch\af31505\loch\f2 - EXAMPLE 19 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSSc\hich\af2\dbch\af31505\loch\f2 ript >.\\ADDS_Inventory_V3.ps1 -ADForest corp.carlwebster.com -Folder
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest corp.carlwebster.com -Folder
 \par \hich\af2\dbch\af31505\loch\f2     \\\\FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries\hich\af2\dbch\af31505\loch\f2  for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to t\hich\af2\dbch\af31505\loch\f2 he value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The output file }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 is}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
@@ -1487,7 +1499,7 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -----------\hich\af2\dbch\af31505\loch\f2 --------------- EXAMPLE 20 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Section Forest
 \par 
@@ -1495,46 +1507,46 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value\hich\af2\dbch\af31505\loch\f2  of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerNam\hich\af2\dbch\af31505\loch\f2 e.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The report \hich\af2\dbch\af31505\loch\f2 include}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\hich\af2\dbch\af31505\loch\f2  only the Forest section.
-\par 
-\par 
+\par \hich\af2\dbch\af31505\loch\f2     The report include}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+ only the Forest section.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- E\hich\af2\dbch\af31505\loch\f2 XAMPLE 21 --------------------------
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Section groups, misc -ADForest
-\par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com -ServerName PrimaryDC.websterslab.com
+\par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com -ServerName PrimaryDC.websterslab\hich\af2\dbch\af31505\loch\f2 .com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com for ADForest.
-\par \hich\af2\dbch\af31505\loch\f2     PrimaryDC.webste\hich\af2\dbch\af31505\loch\f2 rslab.com for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     PrimaryDC.websterslab.com for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The report \hich\af2\dbch\af31505\loch\f2 include}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\hich\af2\dbch\af31505\loch\f2  only the Groups and Miscellaneous sections.
-\par 
-\par 
+\par \hich\af2\dbch\af31505\loch\f2     The report include}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+ only the Groups and Miscellaneous sections.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -MaxDetails
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -----------------------\hich\af2\dbch\af31505\loch\f2 --- EXAMPLE 22 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -MaxDetails
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
 \par \hich\af2\dbch\af31505\loch\f2         DCDNSInfo       = True
 \par \hich\af2\dbch\af31505\loch\f2         GPOInheritance  = True
-\par \hich\af2\dbch\af31505\loch\f2         Hardware        = True
+\par \hich\af2\dbch\af31505\loch\f2         Hardware        =\hich\af2\dbch\af31505\loch\f2  True
 \par \hich\af2\dbch\af31505\loch\f2         IncludeUserInfo = True
-\par \hich\af2\dbch\af31505\loch\f2         Services        = Tr\hich\af2\dbch\af31505\loch\f2 ue
+\par \hich\af2\dbch\af31505\loch\f2         Services        = True
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Section         = "All"
 \par 
@@ -1544,19 +1556,19 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer mail.domain.tld -From
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 AD}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
-Admin@domain.tld -To ITGroup@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 AD}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 Admin@domain.tld -To ITGroup@domain.tld
 \par 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server mail.domain.tld, sending from \hich\af2\dbch\af31505\loch\f2 ADAdmin@domain.tld\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14952143 
+\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server mail.domain.tld, sending from ADAdmin@domain.tld }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 and sending to ITGroup@domain.tld.
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
 The script uses the default SMTP port 25 and does not use SSL.
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
-If the current user's credentials are not valid to send email, the sc\hich\af2\dbch\af31505\loch\f2 ript prompts }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 
+\hich\af2\dbch\af31505\loch\f2 email, the script prompts }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 the user to enter valid credentials.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
@@ -1564,42 +1576,42 @@ If the current user's credentials are not valid to send email, the sc\hich\af2\d
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -SmtpServer mailrelay.domain.tld -From
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer mai\hich\af2\dbch\af31505\loch\f2 lrelay.domain.tld -From
 \par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To ITGroup@domain.tld
 \par 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 ***SENDING UNAUTHENTICATED EMAIL***
 \par 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server mailrelay.do
-\hich\af2\dbch\af31505\loch\f2 main.tld, sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+The script uses the email server mailrelay.domain.tld, sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 anonymous@domain.tld and sending to ITGroup@domain.tld.
 \par 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
-To send an unauthenticated email using an email relay server requires the From email }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 To s\hich\af2\dbch\af31505\loch\f2 
+end an unauthenticated email using an email relay server requires the From email }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 account to use the name Anonymous.
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
-The script uses the default SMTP port 25 and does\hich\af2\dbch\af31505\loch\f2  not use SSL.
+The script uses the default SMTP port 25 and does not use SSL.
 \par \tab 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 ***GMAIL/G SUITE SMTP RELAY***
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK 
-\hich\af2\dbch\af31505\loch\f2 "https://support.google.com/a/answer/2956491?hl=en"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 {\*\datafield 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://suppor
+\hich\af2\dbch\af31505\loch\f2 t.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
-HYPERLINK "https://support.google.com/a/answer/176600?hl=en"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 {\*\datafield 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/
+\hich\af2\dbch\af31505\loch\f2 answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
 To send an email using a Gmail or g-suite account, you may have to turn ON the "Less }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 secure app access"\hich\af2\dbch\af31505\loch\f2  option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 secure app access" option on your account.
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 ***GMAIL/G SUITE SMTP RELAY***
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
-The script generates an anonymous, secure password for the \hich\af2\dbch\af31505\loch\f2 anonymous@domain.tld\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+The script generates an anonymous, secure password for the anonymous@domain.tld }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 account.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
@@ -1607,24 +1619,26 @@ The script generates an anonymous, secure password for the \hich\af2\dbch\af3150
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer
-\par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
+\par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protecti\hich\af2\dbch\af31505\loch\f2 on.outlook.com -UseSSL -From
 \par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2 
- HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
+ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-applica\hich\af2\dbch\af31505\loch\f2 tion-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
+{\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900460075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-dev\hich\af2\dbch\af31505\loch\f2 
-ice-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 h\hich\af2\dbch\af31505\loch\f2 
+ttps://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server labaddomain-com\hich\af2\dbch\af31505\loch\f2 .mail.protection.outlook.com, sending }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email \hich\af2\dbch\af31505\loch\f2 server labaddomain-com.mail.protection.outlook.com, sending }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 from SomeEmailAddress@labaddomain.com and sending to ITGroupDL@labaddomain.com.
 \par 
@@ -1635,12 +1649,11 @@ The script uses the default SMTP port 25 and SSL.}{\rtlch\fcs1 \af2\afs18 \ltrch
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer smtp.office3\hich\af2\dbch\af31505\loch\f2 65.com -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server smtp.office365.com on port 587 using SSL\hich\af2\dbch\af31505\loch\f2 , sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
-
+\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server smtp.office365.com on port 587 using SSL, sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 webster@carlwebster.com and sending to ITGroup@carlwebster.com.
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
@@ -1652,24 +1665,25 @@ If the current user's credentials are not valid to send an email, the script pro
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScr\hich\af2\dbch\af31505\loch\f2 ipt >.\\ADDS_Inventory_V3.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer \hich\af2\dbch\af31505\loch\f2 smtp.gmail.com -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par \hich\af2\dbch\af31505\loch\f2     To send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
 email using a Gmail or g-suite account, you may have to turn ON}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2 the "Less }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 secure a\hich\af2\dbch\af31505\loch\f2 pp access" option on your account.
-\par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 secure app access" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   *** NOTE ***
 \par 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server smtp.gmail.com on port 587 using SSL, sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 webster@gmail.com and sending to ITGroup@carlwebster.com.
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
-If the current user's credentials are not valid to send email, the script prompts the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 user to enter valid credentials.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-
+If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 
+\hich\af2\dbch\af31505\loch\f2 email, the script prompts }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 th\hich\af2\dbch\af31505\loch\f2 e \hich\af2\dbch\af31505\loch\f2 user to enter valid credentials.}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
@@ -1791,8 +1805,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000080fc
-d20ff905d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000005082
+8a468b07d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/ADDS_Inventory_V3_ReadMe.rtf
+++ b/ADDS_Inventory_V3_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -87,16 +87,16 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589\listoverridecount0\ls2}
 {\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1818835589\listoverridecount9{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}
 {\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat
-\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid407474\rsid412309\rsid667579\rsid741398\rsid854968\rsid880017\rsid1520287\rsid1529376\rsid2638156\rsid2710199\rsid2974686
-\rsid3342358\rsid3477011\rsid3828116\rsid3830441\rsid4281248\rsid4467197\rsid4483701\rsid4945864\rsid5315553\rsid5720771\rsid5767175\rsid5849890\rsid5904556\rsid6038932\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7681868\rsid7695940\rsid8013811
-\rsid8220290\rsid8793422\rsid9243658\rsid9252303\rsid9512169\rsid9727541\rsid9838801\rsid9848053\rsid10101060\rsid10290913\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11433897\rsid11488686\rsid11602030\rsid12197314\rsid12322737
-\rsid12343757\rsid12588820\rsid12675704\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13511313\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14176547\rsid14566444\rsid14697282\rsid14893653\rsid15166704\rsid15355254
-\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}
-{\revtim\yr2021\mo1\dy9\hr9\min46}{\version55}{\edmins600}{\nofpages23}{\nofwords6843}{\nofchars39007}{\nofcharsws45759}{\vern15}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid407474\rsid412309\rsid667579\rsid741398\rsid854968\rsid880017\rsid1520287\rsid1529376\rsid1780561\rsid2638156\rsid2710199
+\rsid2974686\rsid3342358\rsid3477011\rsid3828116\rsid3830441\rsid4281248\rsid4467197\rsid4483701\rsid4945864\rsid5315553\rsid5720771\rsid5767175\rsid5849890\rsid5904556\rsid6038932\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7681868\rsid7695940
+\rsid8013811\rsid8220290\rsid8793422\rsid9243658\rsid9252303\rsid9512169\rsid9727541\rsid9838801\rsid9848053\rsid10101060\rsid10290913\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11433897\rsid11488686\rsid11602030\rsid12197314
+\rsid12322737\rsid12343757\rsid12588820\rsid12675704\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13511313\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14176547\rsid14566444\rsid14697282\rsid14893653\rsid14952143
+\rsid15166704\rsid15355254\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}
+{\revtim\yr2021\mo2\dy18\hr7\min22}{\version57}{\edmins652}{\nofpages23}{\nofwords6818}{\nofchars38864}{\nofcharsws45591}{\vern17}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
 \paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwNKgFAFm+xIItAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwNKwFABiP35stAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -266,26 +266,26 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 At least one Windows Server 2008 R2 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 or later }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 domain controller.
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 2.\tab}\hich\af37\dbch\af31505\loch\f37 
-At least one Windows 7 SP1 or later computer with the Remote Server Administration Tools (RSAT) installed.
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 2.\tab}\hich\af37\dbch\af31505\loch\f37 At leas\hich\af37\dbch\af31505\loch\f37 
+t one Windows 7 SP1 or later computer with the Remote Server Administration Tools (RSAT) installed.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid11602030\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 RSAT for Windows 7 SP1 is available here,}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 
-HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24\hich\af37\dbch\af31505\loch\f37 "}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
+HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100630065003500
-65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab000349}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 R\hich\af37\dbch\af31505\loch\f37 SAT for Windows 8 is available here, }
 {\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab000388}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -293,7 +293,7 @@ HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12916989 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c0000006500000003020006}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c000000650000000302000600}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid13858952 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952\charrsid13858952 
 
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
@@ -364,11 +364,8 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid10945524 \hich\af43\dbch\af31505\loch\f43 Help Text
 \par }\pard\plain \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10945524 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
 \ltrch\fcs0 \insrsid10945524 
-\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 PS C:\\webster> get-help .\\
-ADDS_Inventory_V3.ps1 -full
-\par 
-\par \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     C:\\webster\\ADDS_Inventory_V3.ps1
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 NAME
+\par \hich\af2\dbch\af31505\loch\f2     C:\\\hich\af2\dbch\af31505\loch\f2 webster\\ADDS_Inventory_V3.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
 \par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft Active Directory Forest.
@@ -376,18 +373,19 @@ ADDS_Inventory_V3.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
 \par \hich\af2\dbch\af31505\loch\f2     C:\\webster\\ADDS_Inventory_V3.ps1 [-ADDomain <String>] [-ADForest <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-MaxDetails] [-HTML] [-Text] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-MaxDetails] [-HTML] [-T\hich\af2\dbch\af31505\loch\f2 
+ext] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 <String>] [-Log] [-ScriptInfo] [-DCDNSInfo] [-GPOInheritance] [-Hardware] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-IncludeUserInfo\hich\af2\dbch\af31505\loch\f2 ] [-Section <String[]>] [-Services] [-MSWord] [-PDF] }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-IncludeUserInfo] [-Section <String[]>] [-Services] [-MSWord] [-PDF] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyEmail <String>] [-Company\hich\af2\dbch\af31505\loch\f2 Fax <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5315553 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 <String>] [-SmtpPort <Int32>] [-SmtpServer\hich\af2\dbch\af31505\loch\f2 
- <String>] [-SuperVerbose] [-From <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 <String>] [-SmtpPort <Int32>] [-SmtpServer <String>] [-SuperVerbose] [-From <String>] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 [-To <String>] [-UseSSL] [<CommonParameters>]
 \par 
 \par 
@@ -395,13 +393,14 @@ ADDS_Inventory_V3.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft Active Directory Forest using Microsoft
 \par \hich\af2\dbch\af31505\loch\f2     PowerShell, Word, plain text, or HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Word o\hich\af2\dbch\af31505\loch\f2 r PDF document, text, or HTML file named after the Active Directory
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Word or PDF document, text, or HTML file named after the Active Directory
 \par \hich\af2\dbch\af31505\loch\f2     Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Version 3.0 changes the default output report from Word to HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Version 3.0 change\hich\af2\dbch\af31505\loch\f2 s the default output report from Word to HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Word and PDF document includes a Cover Page, Table of Contents and Footer.
-\par \hich\af2\dbch\af31505\loch\f2     Includes support for t\hich\af2\dbch\af31505\loch\f2 he following language versions of Microsoft Word:
+\par \hich\af2\dbch\af31505\loch\f2     Word and PDF document includes a Cover Page, Table of Contents}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2  and Footer.
+\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
 \par \hich\af2\dbch\af31505\loch\f2         Danish
@@ -417,64 +416,67 @@ ADDS_Inventory_V3.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script requires at least PowerShell version 3 but runs best in version 5.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script will output in Text and HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Word is \hich\af2\dbch\af31505\loch\f2 NOT needed to run the script. This script \hich\af2\dbch\af31505\loch\f2 output}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  in Text and HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a domain controller. This scr\hich\af2\dbch\af31505\loch\f2 ipt was developed
+\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a domain controller. This script was developed
 \par \hich\af2\dbch\af31505\loch\f2     and run from a Windows 10 VM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     While most of the script can be run with a non-admin account, there are some features
+\par \hich\af2\dbch\af31505\loch\f2     While most of the script can be run with a non-admin ac\hich\af2\dbch\af31505\loch\f2 count, there are some features
 \par \hich\af2\dbch\af31505\loch\f2     that will not or may not work without domain admin or enterprise admin rights.
-\par \hich\af2\dbch\af31505\loch\f2     The Hardware and Services \hich\af2\dbch\af31505\loch\f2 parameters require domain admin privileges.
+\par \hich\af2\dbch\af31505\loch\f2     The Hardware and Services parameters require domain admin privileges.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script does gathering of information on Time Server and AD database, log file, and
+\par \hich\af2\dbch\af31505\loch\f2     The script \hich\af2\dbch\af31505\loch\f2 gather}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 information on }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 Time Server and AD \hich\af2\dbch\af31505\loch\f2 database, log file, and
 \par \hich\af2\dbch\af31505\loch\f2     SYSVOL locations. Those require access to the registry on each domain controller, which
-\par \hich\af2\dbch\af31505\loch\f2     means the script should \hich\af2\dbch\af31505\loch\f2 now always be run from an elevated PowerShell session with an
+\par \hich\af2\dbch\af31505\loch\f2     means the script should now always be run from an elevated PowerShell session with an
 \par \hich\af2\dbch\af31505\loch\f2     account with a minimum of domain admin rights.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Running the script in a forest with multiple domains requires Enterprise Admin rights.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The count of all users may not be accurate if \hich\af2\dbch\af31505\loch\f2 the user running the script does not have
+\par \hich\af2\dbch\af31505\loch\f2     The count of all users may not be accurate if the user running the script does not have
 \par \hich\af2\dbch\af31505\loch\f2     the necessary permissions on all user objects.  In that case, there may be user accounts
 \par \hich\af2\dbch\af31505\loch\f2     classified as "unknown".
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To run the script from a workstation, RSAT is required.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
-HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 7 with Service Pack 1\hich\af2\dbch\af31505\loch\f2  (SP1)
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100630065003500
-65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tool\hich\af2\dbch\af31505\loch\f2 s for Windows 8
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://c\hich\af2\dbch\af31505\loch\f2 
-arlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8.1
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://carlwebster.sharefile.com/d-s37
-\hich\af2\dbch\af31505\loch\f2 209afb73dc48f497745924ed854226"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https\hich\af2\dbch\af31505\loch\f2 
+://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003c4}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s37209afb73dc4\hich\af2\dbch\af31505\loch\f2 8f497745924ed854226}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administr\hich\af2\dbch\af31505\loch\f2 ation Tools for Windows 10
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK \hich\af2\dbch\af31505\loch\f2 
-"http://www.microsoft.com/en-us/download/details.aspx?id=45520"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 10
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
 \par \hich\af2\dbch\af31505\loch\f2     -ADDomain <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory domain object by providing one of the following
-\par \hich\af2\dbch\af31505\loch\f2         property values. The identifi\hich\af2\dbch\af31505\loch\f2 er in parentheses is the LDAP display name for the
+\par \hich\af2\dbch\af31505\loch\f2         property values. The id\hich\af2\dbch\af31505\loch\f2 entifier in parentheses is the LDAP display name for the
 \par \hich\af2\dbch\af31505\loch\f2         attribute. All values are for the domainDNS object that represents the domain.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Distinguished Name
@@ -483,7 +485,7 @@ arlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"\hich\af2\dbch\af31
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         GUID (objectGUID)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Example: b9fa5fbd-4334-4a98-85f1-3a3a44069fc6
+\par \hich\af2\dbch\af31505\loch\f2         Example: b9fa5fbd-4334-4a98-85f1-3a3a44069fc6
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Security Identifier (objectSid)
 \par 
@@ -500,15 +502,15 @@ arlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"\hich\af2\dbch\af31
 \par \hich\af2\dbch\af31505\loch\f2         If both ADForest and ADDomain are specified, ADDomain takes precedence.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?         \hich\af2\dbch\af31505\loch\f2            named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ADForest <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory forest object by providing one of the following
-\par \hich\af2\dbch\af31505\loch\f2         attribute val\hich\af2\dbch\af31505\loch\f2 ues.
-\par \hich\af2\dbch\af31505\loch\f2         The identifier in parentheses is the LDAP display name for the attribute.
+\par \hich\af2\dbch\af31505\loch\f2         attribute values.
+\par \hich\af2\dbch\af31505\loch\f2         The identifier in parentheses is th\hich\af2\dbch\af31505\loch\f2 e LDAP display name for the attribute.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Fully qualified domain name
 \par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain.com
@@ -533,7 +535,8 @@ arlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"\hich\af2\dbch\af31
 \par \hich\af2\dbch\af31505\loch\f2         Specifies which domain controller to use to run the script against.
 \par \hich\af2\dbch\af31505\loch\f2         If ADForest is a trusted forest, then ComputerName is required to detect the
 \par \hich\af2\dbch\af31505\loch\f2         existence of ADForest.
-\par \hich\af2\dbch\af31505\loch\f2         Co\hich\af2\dbch\af31505\loch\f2 mputerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
+\par \hich\af2\dbch\af31505\loch\f2         Co\hich\af2\dbch\af31505\loch\f2 mputerName can be entered as the NetBIOS name, FQDN, localhost}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  or IP Address.
 \par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and used.
 \par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and use the actual
 \par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 computer name.
@@ -614,7 +617,8 @@ arlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"\hich\af2\dbch\af31
 \par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
-\par \hich\af2\dbch\af31505\loch\f2         The text\hich\af2\dbch\af31505\loch\f2  file is placed in the same folder from where the script is run.
+\par \hich\af2\dbch\af31505\loch\f2         The text\hich\af2\dbch\af31505\loch\f2  file is placed in the same folder from where the script \hich\af2\dbch\af31505\loch\f2 run}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 .
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
@@ -636,113 +640,124 @@ arlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"\hich\af2\dbch\af31
 \par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?       \hich\af2\dbch\af31505\loch\f2              named
+\par \hich\af2\dbch\af31505\loch\f2         Required?       \hich\af2\dbch\af31505\loch\f2              false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
-\par \hich\af2\dbch\af31505\loch\f2         Th\hich\af2\dbch\af31505\loch\f2 e text file is placed in the same folder from where the script is run.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs information \hich\af2\dbch\af31505\loch\f2 about the script to a text file.
+\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 r}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 un}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 .
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Default value                False
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -DCDNSInfo [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather, for each domain controller, the IP Address, and each DNS server
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  configured.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain
+\par \hich\af2\dbch\af31505\loch\f2         configured.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 to}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2  run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardwa\hich\af2\dbch\af31505\loch\f2 re information (i.e.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add an extra section to the report.
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter \hich\af2\dbch\af31505\loch\f2 add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  an extra section to the report.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?              \hich\af2\dbch\af31505\loch\f2       false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -GPOInheritance [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         In the Group Policies b\hich\af2\dbch\af31505\loch\f2 y OU section, adds Inherited GPOs in addition to the GPOs
-\par \hich\af2\dbch\af31505\loch\f2         directly linked.
+\par \hich\af2\dbch\af31505\loch\f2         In the Group Policies by OU section\hich\af2\dbch\af31505\loch\f2  adds Inherited GPOs in addition to the GPOs
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        directly linked.
 \par \hich\af2\dbch\af31505\loch\f2         Adds a second column to the table GPO Type.
-\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by d\hich\af2\dbch\af31505\loch\f2 efault.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of GPO.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard charact\hich\af2\dbch\af31505\loch\f2 ers?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor, and
 \par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2         This parameter requires the script }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 to run}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         using a\hich\af2\dbch\af31505\loch\f2 n account with permission to retrieve hardware information (i.e.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes\hich\af2\dbch\af31505\loch\f2  to run the script and
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2         Selecting this parameter \hich\af2\dbch\af31505\loch\f2 add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  to both the time it takes to run the script and
 \par \hich\af2\dbch\af31505\loch\f2         size of the report.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inpu\hich\af2\dbch\af31505\loch\f2 t?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -IncludeUserInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         For the User Miscellaneous Data section outputs a table with the SamAccountName
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        For the User Miscellaneous Data section outputs a table with the SamAccountName
 \par \hich\af2\dbch\af31505\loch\f2         and DistinguishedName of the users in the All Users counts:
 \par 
 \par \hich\af2\dbch\af31505\loch\f2                 Disabled users
 \par \hich\af2\dbch\af31505\loch\f2                 Unknown users
 \par \hich\af2\dbch\af31505\loch\f2                 Locked out users
-\par \hich\af2\dbch\af31505\loch\f2                 All users with password expired
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           All users with password expired
 \par \hich\af2\dbch\af31505\loch\f2                 All users whose password never expires
 \par \hich\af2\dbch\af31505\loch\f2                 All users with password not required
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2            All users who cannot change password
+\par \hich\af2\dbch\af31505\loch\f2                 All users who cannot change password
 \par \hich\af2\dbch\af31505\loch\f2                 All users with SID History
 \par \hich\af2\dbch\af31505\loch\f2                 All users with Homedrive set in ADUC
 \par \hich\af2\dbch\af31505\loch\f2                 All users whose Primary Group is not Domain Users
-\par \hich\af2\dbch\af31505\loch\f2                 All users with RDS HomeDrive s\hich\af2\dbch\af31505\loch\f2 et in ADUC
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         The Text output option is limited to the first 25 characters of the SamAccountName
+\par \hich\af2\dbch\af31505\loch\f2                 All users with RDS HomeDrive set in ADUC}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 All Names in the ForeignSecurityPrincipals container that are orphan SIDs}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid5315553 
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2         The Text output option is li\hich\af2\dbch\af31505\loch\f2 mited to the first 25 characters of the SamAccountName
 \par \hich\af2\dbch\af31505\loch\f2         and the first 116 characters of the DistinguishedName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of IU.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?      \hich\af2\dbch\af31505\loch\f2  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Section <String[]>
 \par \hich\af2\dbch\af31505\loch\f2         Processes one or more sections of the report.
-\par \hich\af2\dbch\af31505\loch\f2         Valid options are:
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Valid options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Forest
 \par \hich\af2\dbch\af31505\loch\f2                 Sites
-\par \hich\af2\dbch\af31505\loch\f2                 Domains (includes Domain Controllers an\hich\af2\dbch\af31505\loch\f2 d optional Hardware, Services and
+\par \hich\af2\dbch\af31505\loch\f2                 Domains (includes Domain Controllers and optional Hardware, Services and
 \par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo)
 \par \hich\af2\dbch\af31505\loch\f2                 OUs (Organizational Units)
 \par \hich\af2\dbch\af31505\loch\f2                 Groups
-\par \hich\af2\dbch\af31505\loch\f2                 GPOs
+\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       GPOs
 \par \hich\af2\dbch\af31505\loch\f2                 Misc (Miscellaneous data)
 \par \hich\af2\dbch\af31505\loch\f2                 All
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to All sectio\hich\af2\dbch\af31505\loch\f2 ns.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to All sections.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Multiple sections are separated by a comma. -Section forest, domains
 \par 
@@ -753,27 +768,27 @@ arlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"\hich\af2\dbch\af31
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Services [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gather information on all services running on domain controllers.
-\par \hich\af2\dbch\af31505\loch\f2         Servers that are configured to automatically start bu\hich\af2\dbch\af31505\loch\f2 t are not running will be
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Gather information on all services running on domain controllers.
+\par \hich\af2\dbch\af31505\loch\f2         Servers that are configured to automatically start but are not running will be
 \par \hich\af2\dbch\af31505\loch\f2         colored in red.
 \par \hich\af2\dbch\af31505\loch\f2         Used on Domain Controllers only.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve service information (i.e. \hich\af2\dbch\af31505\loch\f2 Domain
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the sc\hich\af2\dbch\af31505\loch\f2 ript be run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve service information (i.e. Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
 \par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
-\par \hich\af2\dbch\af31505\loch\f2         size of the report.
+\par \hich\af2\dbch\af31505\loch\f2         size of \hich\af2\dbch\af31505\loch\f2 the report.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?       \hich\af2\dbch\af31505\loch\f2              named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Microsoft Word is no longer the default r\hich\af2\dbch\af31505\loch\f2 eport format.
+\par \hich\af2\dbch\af31505\loch\f2         Microsoft Word is no longer the default report format.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -783,25 +798,25 @@ arlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"\hich\af2\dbch\af31
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         Sav\hich\af2\dbch\af31505\loch\f2 eAs PDF file instead of DOCX file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter \hich\af2\dbch\af31505\loch\f2 requires Microsoft Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses Word's SaveAs PDF capability.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is d\hich\af2\dbch\af31505\loch\f2 isabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value \hich\af2\dbch\af31505\loch\f2                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress\hich\af2\dbch\af31505\loch\f2  <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cove\hich\af2\dbch\af31505\loch\f2 r Pages have an Address field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
@@ -809,25 +824,25 @@ arlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"\hich\af2\dbch\af31
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2          \hich\af2\dbch\af31505\loch\f2        Tiles (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the \hich\af2\dbch\af31505\loch\f2 MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard cha\hich\af2\dbch\af31505\loch\f2 racters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  The following Cover Pages have an Email field:
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is on\hich\af2\dbch\af31505\loch\f2 ly valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -837,113 +852,114 @@ arlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"\hich\af2\dbch\af31
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the C\hich\af2\dbch\af31505\loch\f2 over Page, if the Cover Page has the Fax field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2          Contrast (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?    \hich\af2\dbch\af31505\loch\f2                 named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyName \hich\af2\dbch\af31505\loch\f2 <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         Default value is contained in
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
 \par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
-\par \hich\af2\dbch\af31505\loch\f2         If either regis\hich\af2\dbch\af31505\loch\f2 try key does not exist and this parameter is not specified, the report
+\par \hich\af2\dbch\af31505\loch\f2         If either registry key does not exist and this parameter is not specified, the report
 \par \hich\af2\dbch\af31505\loch\f2         will not contain a Company Name on the cover page.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This par\hich\af2\dbch\af31505\loch\f2 ameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fal\hich\af2\dbch\af31505\loch\f2 se
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page if the Cover Page has the Phone field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word\hich\af2\dbch\af31505\loch\f2  2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept \hich\af2\dbch\af31505\loch\f2 pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input? \hich\af2\dbch\af31505\loch\f2       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
-\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
+\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  and 2016 are supported.
+
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, \hich\af2\dbch\af31505\loch\f2 mostly
+\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2\hich\af2\dbch\af31505\loch\f2 010/2013/2016. Doesn't work in 2013 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
 \par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast \hich\af2\dbch\af31505\loch\f2 (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Conservative\hich\af2\dbch\af31505\loch\f2  (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Grid (Wor\hich\af2\dbch\af31505\loch\f2 d 2010/2013/2016. Works in 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Wor\hich\af2\dbch\af31505\loch\f2 d 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Wo\hich\af2\dbch\af31505\loch\f2 rd 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font change\hich\af2\dbch\af31505\loch\f2 d to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
-\par \hich\af2\dbch\af31505\loch\f2                 36\hich\af2\dbch\af31505\loch\f2  point)
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top d\hich\af2\dbch\af31505\loch\f2 ate is manually changed to
+\par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2               resized or font changed to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Semaphor\hich\af2\dbch\af31505\loch\f2 e (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Wor\hich\af2\dbch\af31505\loch\f2 d 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2                Stacks (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. W\hich\af2\dbch\af31505\loch\f2 orks)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The default\hich\af2\dbch\af31505\loch\f2  value is Sideline.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value     \hich\af2\dbch\af31505\loch\f2            Sideline
+\par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
-\par \hich\af2\dbch\af31505\loch\f2         This parame\hich\af2\dbch\af31505\loch\f2 ter has an alias of UN.
+\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:us\hich\af2\dbch\af31505\loch\f2 ername
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -957,14 +973,14 @@ arlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"\hich\af2\dbch\af31
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Require\hich\af2\dbch\af31505\loch\f2 d?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional em\hich\af2\dbch\af31505\loch\f2 ail server to send the output report(s).
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer\hich\af2\dbch\af31505\loch\f2  <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report(s).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If From or To are used, this is a required parameter.
 \par 
@@ -985,24 +1001,24 @@ arlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"\hich\af2\dbch\af31
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or To are used, this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or To are used, this is a\hich\af2\dbch\af31505\loch\f2  required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?    \hich\af2\dbch\af31505\loch\f2                 false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the \hich\af2\dbch\af31505\loch\f2 username for the To email address.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  If SmtpServer or From are used, this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or From are used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fals\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fals\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
@@ -1015,21 +1031,21 @@ arlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"\hich\af2\dbch\af31
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
-\par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable,\hich\af2\dbch\af31505\loch\f2  WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose,\hich\af2\dbch\af31505\loch\f2  Debug,
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
-HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2 OU\hich\af2\dbch\af31505\loch\f2 TPUTS
-\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a Word or PDF document.
+\par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
+\par \hich\af2\dbch\af31505\loch\f2     No objects are output f\hich\af2\dbch\af31505\loch\f2 rom this script.  This script creates a Word or PDF document.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
@@ -1038,9 +1054,9 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2         NAME: ADDS_Inventory_V3.ps1
 \par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.02
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and Michael B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: January 9, 2021
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 February 18, 2021}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     --\hich\af2\dbch\af31505\loch\f2 ------------------------ EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1
 \par 
@@ -1048,22 +1064,25 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNS\hich\af2\dbch\af31505\loch\f2 DOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN\hich\af2\dbch\af31505\loch\f2 , then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Invent\hich\af2\dbch\af31505\loch\f2 ory_V3.ps1 -MSWord
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3\hich\af2\dbch\af31505\loch\f2 .ps1 -MSWord
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username \hich\af2\dbch\af31505\loch\f2 = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Admi\hich\af2\dbch\af31505\loch\f2 nistrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1072,8 +1091,10 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
@@ -1087,15 +1108,17 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain \hich\af2\dbch\af31505\loch\f2 controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     a domain \hich\af2\dbch\af31505\loch\f2 controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}
+{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADDomain}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -ADDomain}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 child.company.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
@@ -1103,8 +1126,10 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     child.company.tld for the AD Domain.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will us\hich\af2\dbch\af31505\loch\f2 e that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a globa\hich\af2\dbch\af31505\loch\f2 l catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}
+{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
@@ -1114,15 +1139,17 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest parent.company.tld -ADDomain
 \par \hich\af2\dbch\af31505\loch\f2     child.company.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     Cre\hich\af2\dbch\af31505\loch\f2 ates an HTML report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     B\hich\af2\dbch\af31505\loch\f2 ecause both ADForest and ADDomain are specified, ADDomain wins and child.company.tld
+\par \hich\af2\dbch\af31505\loch\f2     Because both ADForest and ADDomain are specified, ADDomain wins and child.company.tld
 \par \hich\af2\dbch\af31505\loch\f2     is used for AD Domain.
 \par \hich\af2\dbch\af31505\loch\f2     ADForest is set to the value of ADDomain.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a d\hich\af2\dbch\af31505\loch\f2 omain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the\hich\af2\dbch\af31505\loch\f2  script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
@@ -1134,54 +1161,64 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_U\hich\af2\dbch\af31505\loch\f2 SER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline fo\hich\af2\dbch\af31505\loch\f2 r the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     co\hich\af2\dbch\af31505\loch\f2 mpany.tld for the AD Forest
-\par \hich\af2\dbch\af31505\loch\f2     The script will be run remotely on the DC01 domain controller.
+\par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest
+\par \hich\af2\dbch\af31505\loch\f2     The script \hich\af2\dbch\af31505\loch\f2 run}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2  remotely on the DC01 domain controller.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values and save}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  the document as a PDF file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
+\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebst\hich\af2\dbch\af31505\loch\f2 er.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, \hich\af2\dbch\af31505\loch\f2 then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -----------------\hich\af2\dbch\af31505\loch\f2 --------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.p\hich\af2\dbch\af31505\loch\f2 s1 -Text -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Text -ADForest corp.carlwebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a formatted text file.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values and save}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  the document as a formatted text file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
@@ -1190,30 +1227,39 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -HTML -ADForest corp.carlwebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as an HTML file.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values and save}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  the document as an HTML file.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOM\hich\af2\dbch\af31505\loch\f2 AIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
-\par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventor\hich\af2\dbch\af31505\loch\f2 y_V3.ps1 -hardware
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and add additional information for each domain controller
-\par \hich\af2\dbch\af31505\loch\f2     about its hardware.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the \hich\af2\dbch\af31505\loch\f2 AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMP\hich\af2\dbch\af31505\loch\f2 LE 10 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -hardware
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values and add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  additional information for each domain controller}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 about }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 its hardware.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to\hich\af2\dbch\af31505\loch\f2  the value of $Env:USERDNSDOMAIN.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
@@ -1222,34 +1268,46 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -services
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and add additional information for the services running
-\par \hich\af2\dbch\af31505\loch\f2     on each domain controller.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the va\hich\af2\dbch\af31505\loch\f2 lue of $Env:USERDNSDOMAIN.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
-\par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     ----------------\hich\af2\dbch\af31505\loch\f2 ---------- EXAMPLE 12 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -DCDNSInfo
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and add additional information for each domain controller
-\par \hich\af2\dbch\af31505\loch\f2     about its DNS IP configuration.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     An extra section will be added to the end of the report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a\hich\af2\dbch\af31505\loch\f2 n HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values and add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  additional information for the services running}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 on }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 each }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 domain controller.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Comp\hich\af2\dbch\af31505\loch\f2 uterName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, \hich\af2\dbch\af31505\loch\f2 then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.\hich\af2\dbch\af31505\loch\f2 ps1 -DCDNSInfo
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values and add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  additional information for each domain controller}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 about }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 its DNS IP configuration.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     An extra section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 is}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+ added to the end of the report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
@@ -1257,16 +1315,16 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage "Mod" -UserName "Carl Webster" -ComputerName ADDC01
+\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage "Mod" -UserName "Carl We\hich\af2\dbch\af31505\loch\f2 bster" -ComputerName ADDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Con\hich\af2\dbch\af31505\loch\f2 sulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $En\hich\af2\dbch\af31505\loch\f2 v:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Domain Controller named ADDC01 for the ComputerName.
 \par 
@@ -1275,46 +1333,50 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CN "Carl Webster Consulting"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -MSWord -CN "Carl Webster Consulting"
 \par \hich\af2\dbch\af31505\loch\f2     -CP "Mod" -UN "Carl Webster"
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Creates a Microsoft Word report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
-\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias \hich\af2\dbch\af31505\loch\f2 CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $\hich\af2\dbch\af31505\loch\f2 Env:USERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global cata\hich\af2\dbch\af31505\loch\f2 log server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}
+{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------------------------\hich\af2\dbch\af31505\loch\f2 -- EXAMPLE 15 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
-\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2   
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2   
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 Street, London, England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes\hich\af2\dbch\af31505\loch\f2  Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Co\hich\af2\dbch\af31505\loch\f2 nsulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for\hich\af2\dbch\af31505\loch\f2  the Company Phone.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for th\hich\af2\dbch\af31505\loch\f2 e Company Phone.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
@@ -1336,8 +1398,11 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a \hich\af2\dbch\af31505\loch\f2 domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     a \hich\af2\dbch\af31505\loch\f2 domain controller that is also a global catalog server and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 u}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
@@ -1351,13 +1416,17 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 202\hich\af2\dbch\af31505\loch\f2 1-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be company.tld_2021-06-01_1800.docx.
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 2021-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 The o}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 is}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  company.tld_2021-06-01_1800.docx.
+
 \par 
 \par 
 \par 
@@ -1367,44 +1436,53 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Wil\hich\af2\dbch\af31505\loch\f2 l use all default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all defau\hich\af2\dbch\af31505\loch\f2 lt values and save}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  the document as a PDF file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env\hich\af2\dbch\af31505\loch\f2 :username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Adm\hich\af2\dbch\af31505\loch\f2 inistrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queri\hich\af2\dbch\af31505\loch\f2 es for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file n\hich\af2\dbch\af31505\loch\f2 ame.
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 2021-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be corp.carlwebster.com_2021-06-01_1800.PDF
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 The o}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 is}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+ corp.carlwebster.com_2021-06-01_1800.PDF
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest corp.carlwebster.com -Folder
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSSc\hich\af2\dbch\af31505\loch\f2 ript >.\\ADDS_Inventory_V3.ps1 -ADForest corp.carlwebster.com -Folder
 \par \hich\af2\dbch\af31505\loch\f2     \\\\FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script q\hich\af2\dbch\af31505\loch\f2 ueries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries\hich\af2\dbch\af31505\loch\f2  for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The output file will be saved in the path \\\\FileServer\\ShareName.
+\par \hich\af2\dbch\af31505\loch\f2     The output file }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 is}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+ saved in the path \\\\FileServer\\ShareName.
 \par 
 \par 
 \par 
@@ -1418,10 +1496,13 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value\hich\af2\dbch\af31505\loch\f2  of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The report will include only the Forest section.
+\par \hich\af2\dbch\af31505\loch\f2     The report \hich\af2\dbch\af31505\loch\f2 include}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2  only the Forest section.
 \par 
 \par 
 \par 
@@ -1434,16 +1515,17 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com for ADForest.
-\par \hich\af2\dbch\af31505\loch\f2     PrimaryDC.webst\hich\af2\dbch\af31505\loch\f2 erslab.com for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     PrimaryDC.webste\hich\af2\dbch\af31505\loch\f2 rslab.com for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The report will include only the Groups and Miscellaneous sections.
+\par \hich\af2\dbch\af31505\loch\f2     The report \hich\af2\dbch\af31505\loch\f2 include}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2  only the Groups and Miscellaneous sections.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -MaxDetails
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -MaxDetails
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
@@ -1452,7 +1534,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2         GPOInheritance  = True
 \par \hich\af2\dbch\af31505\loch\f2         Hardware        = True
 \par \hich\af2\dbch\af31505\loch\f2         IncludeUserInfo = True
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Services        = True
+\par \hich\af2\dbch\af31505\loch\f2         Services        = Tr\hich\af2\dbch\af31505\loch\f2 ue
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Section         = "All"
 \par 
@@ -1462,96 +1544,110 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer mail.domain.tld -From
-\par \hich\af2\dbch\af31505\loch\f2     XDAdmin@domain.tld -To ITGroup@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 AD}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+Admin@domain.tld -To ITGroup@domain.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
-\par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server mail.domain.tld, sending from \hich\af2\dbch\af31505\loch\f2 ADAdmin@domain.tld\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 and sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+The script uses the default SMTP port 25 and does not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
-\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
-\par 
-\par 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+If the current user's credentials are not valid to send email, the sc\hich\af2\dbch\af31505\loch\f2 ript prompts }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 the user to enter valid credentials.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer mailrelay.domain.tld -From
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -SmtpServer mailrelay.domain.tld -From
 \par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To ITGroup@domain.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 ***SENDING UNAUTHENTICATED EMAIL***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mailrelay.domain.tld, send\hich\af2\dbch\af31505\loch\f2 ing from
-\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld, sending to ITGroup@domain.tld.
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server mailrelay.do
+\hich\af2\dbch\af31505\loch\f2 main.tld, sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 anonymous@domain.tld and sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send unauthenticated email using an email relay server requires the From email account
-\par \hich\af2\dbch\af31505\loch\f2     to use the name Anonymous.
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+To send an unauthenticated email using an email relay server requires the From email }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 account to use the name Anonymous.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not u\hich\af2\dbch\af31505\loch\f2 se SSL.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/\hich\af2\dbch\af31505\loch\f2 
-a/answer/2956491?hl=en"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+The script uses the default SMTP port 25 and does\hich\af2\dbch\af31505\loch\f2  not use SSL.
+\par \tab 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 ***GMAIL/G SUITE SMTP RELAY***
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK 
+\hich\af2\dbch\af31505\loch\f2 "https://support.google.com/a/answer/2956491?hl=en"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
-https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en"
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://support.google.com/a/answer/176600?hl=en"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
-https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
-\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
-\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+To send an email using a Gmail or g-suite account, you may have to turn ON the "Less }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 secure app access"\hich\af2\dbch\af31505\loch\f2  option on your account.
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 ***GMAIL/G SUITE SMTP RELAY***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will generate an anonymous secure password for the anonymous@domain.tld
-\par \hich\af2\dbch\af31505\loch\f2     account.
-\par 
-\par 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+The script generates an anonymous, secure password for the \hich\af2\dbch\af31505\loch\f2 anonymous@domain.tld\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 account.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer
 \par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
-\par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL\hich\af2\dbch\af31505\loch\f2 @labaddomain.com
+\par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
-HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
-{\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900460075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3}
-}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-dev\hich\af2\dbch\af31505\loch\f2 
+ice-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ***OFF\hich\af2\dbch\af31505\loch\f2 ICE 365 Example***
+\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server labaddomain-com.mail.protection.outlook.com,
-\par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server labaddomain-com\hich\af2\dbch\af31505\loch\f2 .mail.protection.outlook.com, sending }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 from SomeEmailAddress@labaddomain.com and sending to ITGroupDL@labaddomain.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will use SSL.
-\par 
-\par 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+The script uses the default SMTP port 25 and SSL.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADD\hich\af2\dbch\af31505\loch\f2 S_Inventory_V3.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer smtp.office3\hich\af2\dbch\af31505\loch\f2 65.com -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
-\par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.\hich\af2\dbch\af31505\loch\f2 com, sending to ITGroup@carlwebster.com.
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server smtp.office365.com on port 587 using SSL\hich\af2\dbch\af31505\loch\f2 , sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 webster@carlwebster.com and sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
-\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
-\par 
-\par 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+If the current user's credentials are not valid to send an email, the script prompts }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 the user to enter valid credentials.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
@@ -1560,17 +1656,21 @@ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/ho
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
-\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
-\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     To send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+email using a Gmail or g-suite account, you may have to turn ON}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 the "Less }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 secure a\hich\af2\dbch\af31505\loch\f2 pp access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.gmail.com on port 587 using SSL,
-\par \hich\af2\dbch\af31505\loch\f2     sending from webster@g\hich\af2\dbch\af31505\loch\f2 mail.com, sending to ITGroup@carlwebster.com.
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server smtp.gmail.com on port 587 using SSL, sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 webster@gmail.com and sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
-\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
-\par 
-\par 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+If the current user's credentials are not valid to send email, the script prompts the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 user to enter valid credentials.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
 9cb2400825e982c78ec7a27cc0c8992416c9d8b2a755fbf74cd25442a820166c2cd933f79e3be372bd1f07b5c3989ca74aaff2422b24eb1b475da5df374fd9ad
@@ -1691,8 +1791,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000f059
-1c969ee6d601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000080fc
+d20ff905d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/ADDS_V3_Script_ChangeLog.txt
+++ b/ADDS_V3_Script_ChangeLog.txt
@@ -13,7 +13,7 @@
 #	Added Domain SID to the Domain Information section
 #	Added SYSVOL State to Function OutputADFileLocations
 #		If SYSVOL State is not 4, highlight in red
-#	Added updates from MBS for MaxPasswordAge
+#	Added updates from Michael B. Smith for MaxPasswordAge
 #		Update Function getDSUsers
 #		Update Function GetMaximumPasswordAge
 #	Changed from using Test-Connection to Test-NetConnection -Port 88

--- a/ADDS_V3_Script_ChangeLog.txt
+++ b/ADDS_V3_Script_ChangeLog.txt
@@ -8,6 +8,37 @@
 #@essentialexch on Twitter
 #https://www.essential.exchange/blog/
 
+#Version 3.03 22-Feb-2021
+#	Added a Try/Catch and -LDAPFilter when checking for the Exchange schema attributes to suppress the error if Exchange is not installed
+#	Added Domain SID to the Domain Information section
+#	Added SYSVOL State to Function OutputADFileLocations
+#		If SYSVOL State is not 4, highlight in red
+#	Added updates from MBS for MaxPasswordAge
+#		Update Function getDSUsers
+#		Update Function GetMaximumPasswordAge
+#	Changed from using Test-Connection to Test-NetConnection -Port 88
+#		Port 88 is the KDC and is unique to DCs (thanks to Matthew Woolnough for the suggestion)
+#	Cleaned up console output
+#	In Function BuildMultiColumnTable:
+#		Prevent a division by 0 error if $MaxLength was 0
+#		Fixed OutOfBounds array error (appears to be a corner case when there are 11 subnets assigned to a Site)
+#	Fixed bug to now catch empty Site Subnet arrays
+#		Added text "No Subnets linked to this site"
+#	Updated Function GetComputerServices to add "***" in the Text output when the service type is Automatic and Status is Stopped
+#	Updated Function getDSUsers to handle processing accounts in the Foreign Security Principals container
+#		Find all orphaned SIDs
+#		Get a count of orphaned SIDs
+#		Added Function OutputFSPUserInfo to output the Orphaned SIDs and the groups those SIDs are members of
+#	Updated Function ProcessGroupInformation to put HTML output in Red when:
+#		Password Last Change is null or not set
+#		Password Never Expires is True
+#		Account is Disabled
+#	Updated the help text
+#	Updated the ReadMe file
+#	When processing Groups for attribute adminCount -eq 1, fixed where the group name doesn’t match the samAccountName or the distinguishedName
+#	When processing Groups that have attribute adminCount -eq 1, check if there was an error retrieving members of the group
+#		If there was an error, add the text "Unable to retrieve group members. Check for orphaned SIDs." in place of the group members
+
 #Version 3.02 9-Jan-2021
 #	Added to the Computer Hardware section, the server's Power Plan
 #	Changed all Write-Verbose statements from Get-Date to Get-Date -Format G as requested by Guy Leech


### PR DESCRIPTION
#Version 3.03 22-Feb-2021
#	Added a Try/Catch and -LDAPFilter when checking for the Exchange schema attributes to suppress the error if Exchange is not installed
#	Added Domain SID to the Domain Information section
#	Added SYSVOL State to Function OutputADFileLocations
#		If SYSVOL State is not 4, highlight in red
#	Added updates from Michael B. Smith for MaxPasswordAge
#		Update Function getDSUsers
#		Update Function GetMaximumPasswordAge
#	Changed from using Test-Connection to Test-NetConnection -Port 88
#		Port 88 is the KDC and is unique to DCs (thanks to Matthew Woolnough for the suggestion)
#	Cleaned up console output
#	In Function BuildMultiColumnTable:
#		Prevent a division by 0 error if $MaxLength was 0
#		Fixed OutOfBounds array error (appears to be a corner case when there are 11 subnets assigned to a Site)
#	Fixed bug to now catch empty Site Subnet arrays
#		Added text "No Subnets linked to this site"
#	Updated Function GetComputerServices to add "***" in the Text output when the service type is Automatic and Status is Stopped
#	Updated Function getDSUsers to handle processing accounts in the Foreign Security Principals container
#		Find all orphaned SIDs
#		Get a count of orphaned SIDs
#		Added Function OutputFSPUserInfo to output the Orphaned SIDs and the groups those SIDs are members of
#	Updated Function ProcessGroupInformation to put HTML output in Red when:
#		Password Last Change is null or not set
#		Password Never Expires is True
#		Account is Disabled
#	Updated the help text
#	Updated the ReadMe file
#	When processing Groups for attribute adminCount -eq 1, fixed where the group name doesn’t match the samAccountName or the distinguishedName
#	When processing Groups that have attribute adminCount -eq 1, check if there was an error retrieving members of the group
#		If there was an error, add the text "Unable to retrieve group members. Check for orphaned SIDs." in place of the group members