### PR TITLE
3.04

### DIFF
--- a/ADDS_Inventory_V3_ReadMe.rtf
+++ b/ADDS_Inventory_V3_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -88,15 +88,15 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 {\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1818835589\listoverridecount9{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}
 {\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat
 \levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid407474\rsid412309\rsid667579\rsid741398\rsid854968\rsid880017\rsid1520287\rsid1529376\rsid1780561\rsid2638156\rsid2710199
-\rsid2974686\rsid3342358\rsid3477011\rsid3828116\rsid3830441\rsid4281248\rsid4467197\rsid4483701\rsid4945864\rsid5315553\rsid5720771\rsid5767175\rsid5849890\rsid5904556\rsid6038932\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7681868\rsid7695940
-\rsid8013811\rsid8220290\rsid8793422\rsid9243658\rsid9252303\rsid9512169\rsid9727541\rsid9838801\rsid9848053\rsid10101060\rsid10290913\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11433897\rsid11488686\rsid11602030\rsid12197314
-\rsid12322737\rsid12343757\rsid12588820\rsid12675704\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13511313\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14176547\rsid14566444\rsid14697282\rsid14893653\rsid14952143
-\rsid15166704\rsid15355254\rsid15760967\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}
-{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo2\dy20\hr7\min21}{\version58}{\edmins670}{\nofpages23}{\nofwords6815}{\nofchars38851}{\nofcharsws45575}{\vern17}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\rsid2974686\rsid3342358\rsid3477011\rsid3828116\rsid3830441\rsid4281248\rsid4467197\rsid4483701\rsid4945864\rsid5315553\rsid5664192\rsid5720771\rsid5767175\rsid5849890\rsid5904556\rsid6038932\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7681868
+\rsid7695940\rsid8013811\rsid8220290\rsid8793422\rsid9243658\rsid9252303\rsid9512169\rsid9727541\rsid9838801\rsid9848053\rsid10101060\rsid10290913\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11433897\rsid11488686\rsid11602030
+\rsid12197314\rsid12322737\rsid12343757\rsid12588820\rsid12675704\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13511313\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14176547\rsid14566444\rsid14697282\rsid14893653
+\rsid14952143\rsid15166704\rsid15355254\rsid15760967\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}
+{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo3\dy6\hr16\min44}{\version59}{\edmins671}{\nofpages23}{\nofwords6815}{\nofchars38847}{\nofcharsws45571}{\vern17}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
 \paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwNKoFANvc8rAtAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwNK4FAJrt6aktAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -273,19 +273,19 @@ t one Windows 7 SP1 or later computer with the Remote Server Administration Tool
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 
 HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100630065003500
-65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab00034932}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab0003493200}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 R\hich\af37\dbch\af31505\loch\f37 SAT for Windows 8 is available here, }
 {\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab00038800}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab0003880029}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030049}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004900}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -293,7 +293,7 @@ HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12916989 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c00000065000000030200060057}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c00000065000000030200060057d1}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid13858952 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952\charrsid13858952 
 
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
@@ -425,12 +425,12 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par \hich\af2\dbch\af31505\loch\f2     that will not or may not work without domain admin or enterprise admin rights.
 \par \hich\af2\dbch\af31505\loch\f2     The Hardware and Services parameters require domain admin privileges.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The \hich\af2\dbch\af31505\loch\f2 script gather}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\hich\af2\dbch\af31505\loch\f2  information on }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
-Time Server and AD database, log file, and
+\par \hich\af2\dbch\af31505\loch\f2     The script gather}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+ information on }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 Ti\hich\af2\dbch\af31505\loch\f2 
+me Server and AD database, log file, and
 \par \hich\af2\dbch\af31505\loch\f2     SYSVOL locations. Those require access to the registry on each domain controller, which
-\par \hich\af2\dbch\af31505\loch\f2     means the script should now always be run from an elevated PowerShell session with \hich\af2\dbch\af31505\loch\f2 an
-\par \hich\af2\dbch\af31505\loch\f2     account with a minimum of domain admin rights.
+\par \hich\af2\dbch\af31505\loch\f2     means the script should now always be run from an elevated PowerShell session with an
+\par \hich\af2\dbch\af31505\loch\f2     account with a minimum of dom\hich\af2\dbch\af31505\loch\f2 ain admin rights.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Running the script in a forest with multiple domains requires Enterprise Admin rights.
 \par 
@@ -444,7 +444,7 @@ Time Server and AD database, log file, and
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100630065003500
-65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab00030026}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab0003002600}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebst\hich\af2\dbch\af31505\loch\f2 er.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
@@ -452,7 +452,7 @@ Time Server and AD database, log file, and
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab00030038}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab0003003800}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
@@ -460,7 +460,7 @@ Time Server and AD database, log file, and
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.\hich\af2\dbch\af31505\loch\f2 
 sharefile.com/d-s37209afb73dc48f497745924ed854226" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003c432}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003c43244}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed\hich\af2\dbch\af31505\loch\f2 854226}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
@@ -468,7 +468,7 @@ sharefile.com/d-s37209afb73dc48f497745924ed854226" }{\rtlch\fcs1 \af2\afs18 \ltr
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030030}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003003000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par 
@@ -480,7 +480,7 @@ sharefile.com/d-s37209afb73dc48f497745924ed854226" }{\rtlch\fcs1 \af2\afs18 \ltr
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Distinguished Name
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Example: \hich\af2\dbch\af31505\loch\f2 DC=labaddomain,DC=com
+\par \hich\af2\dbch\af31505\loch\f2         Example: DC=labaddomain,DC=com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         GUID (objectGUID)
 \par 
@@ -497,7 +497,7 @@ sharefile.com/d-s37209afb73dc48f497745924ed854226" }{\rtlch\fcs1 \af2\afs18 \ltr
 \par \hich\af2\dbch\af31505\loch\f2         Example: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 \hich\af2\dbch\af31505\loch\f2 l}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
 abaddomain.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         NetBIOS domain nam\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2         NetBIOS domain name
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Example: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 \hich\af2\dbch\af31505\loch\f2 labaddomain}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
@@ -506,13 +506,13 @@ abaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?      \hich\af2\dbch\af31505\loch\f2  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       \hich\af2\dbch\af31505\loch\f2 false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ADForest <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory forest object by providing one of the following
 \par \hich\af2\dbch\af31505\loch\f2         attribute values.
-\par \hich\af2\dbch\af31505\loch\f2         The identifier in parentheses is the LDAP display name for the\hich\af2\dbch\af31505\loch\f2  attribute.
+\par \hich\af2\dbch\af31505\loch\f2         The identifier in parentheses is the LDAP display name for the \hich\af2\dbch\af31505\loch\f2 attribute.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Fully qualified domain name
 \par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain.com
@@ -669,8 +669,8 @@ abaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2         configured.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 to}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2  run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\hich\af2\dbch\af31505\loch\f2  Domain
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardwa\hich\af2\dbch\af31505\loch\f2 re information (i.e.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
 \par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2  an extra section to the report.
@@ -678,23 +678,23 @@ abaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -GPOInheritance [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         In the Group Policies by OU section adds Inherited GPOs in addition to the GPOs
-\par \hich\af2\dbch\af31505\loch\f2         directly linked.
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    directly linked.
 \par \hich\af2\dbch\af31505\loch\f2         Adds a second column to the table GPO Type.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         T\hich\af2\dbch\af31505\loch\f2 his parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of GPO.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor, and
@@ -702,62 +702,63 @@ abaddomain.com
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2         This parameter requires the script }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 to run}{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\hich\af2\dbch\af31505\loch\f2  Domain
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retr\hich\af2\dbch\af31505\loch\f2 ieve hardware information (i.e.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2         Selecting this parameter add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  to both the time it takes t\hich\af2\dbch\af31505\loch\f2 o run the script and
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  to both the time it takes to run the script and
 \par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                   \hich\af2\dbch\af31505\loch\f2  false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input\hich\af2\dbch\af31505\loch\f2 ?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -IncludeUserInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         For the User Miscellaneous Data section outputs a table with the SamAccountName
+\par \hich\af2\dbch\af31505\loch\f2         For the User Miscellaneous \hich\af2\dbch\af31505\loch\f2 Data section outputs a table with the SamAccountName
 \par \hich\af2\dbch\af31505\loch\f2         and DistinguishedName of the users in the All Users counts:
 \par 
 \par \hich\af2\dbch\af31505\loch\f2                 Disabled users
 \par \hich\af2\dbch\af31505\loch\f2                 Unknown users
 \par \hich\af2\dbch\af31505\loch\f2                 Locked out users
-\par \hich\af2\dbch\af31505\loch\f2                 All users with password expired
+\par \hich\af2\dbch\af31505\loch\f2                 All users with password \hich\af2\dbch\af31505\loch\f2 expired
 \par \hich\af2\dbch\af31505\loch\f2                 All users whose password never expires
 \par \hich\af2\dbch\af31505\loch\f2                 All users with password not required
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           All users who cannot change password
+\par \hich\af2\dbch\af31505\loch\f2                 All users who cannot change password
 \par \hich\af2\dbch\af31505\loch\f2                 All users with SID History
 \par \hich\af2\dbch\af31505\loch\f2                 All users with Homedrive set in ADUC
 \par \hich\af2\dbch\af31505\loch\f2                 All users whose Primary Group is not Domain Users
 \par \hich\af2\dbch\af31505\loch\f2                 All users with RDS HomeDrive set in ADUC}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 All Names in the ForeignSecurityPrincipals container that are orphan SIDs}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid5315553 
+\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 All Names in the ForeignSecurityPrincipals container that are or\hich\af2\dbch\af31505\loch\f2 phan SIDs}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid5315553 
+
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\par \hich\af2\dbch\af31505\loch\f2         The Text output option is limited \hich\af2\dbch\af31505\loch\f2 to the first 25 characters of the SamAccountName
+\par \hich\af2\dbch\af31505\loch\f2         The Text output option is limited to the first 25 characters of the SamAccountName
 \par \hich\af2\dbch\af31505\loch\f2         and the first 116 characters of the DistinguishedName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of IU.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         P\hich\af2\dbch\af31505\loch\f2 osition?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Section <String[]>
-\par \hich\af2\dbch\af31505\loch\f2         Processes one or more sections of the report.
-\par \hich\af2\dbch\af31505\loch\f2         Valid \hich\af2\dbch\af31505\loch\f2 options are:
+\par \hich\af2\dbch\af31505\loch\f2         Process\hich\af2\dbch\af31505\loch\f2 es one or more sections of the report.
+\par \hich\af2\dbch\af31505\loch\f2         Valid options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Forest
 \par \hich\af2\dbch\af31505\loch\f2                 Sites
 \par \hich\af2\dbch\af31505\loch\f2                 Domains (includes Domain Controllers and optional Hardware, Services and
 \par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo)
-\par \hich\af2\dbch\af31505\loch\f2                 OUs (Organizational Units)
+\par \hich\af2\dbch\af31505\loch\f2                 OUs (Organiza\hich\af2\dbch\af31505\loch\f2 tional Units)
 \par \hich\af2\dbch\af31505\loch\f2                 Groups
-\par \hich\af2\dbch\af31505\loch\f2                 \hich\af2\dbch\af31505\loch\f2 GPOs
+\par \hich\af2\dbch\af31505\loch\f2                 GPOs
 \par \hich\af2\dbch\af31505\loch\f2                 Misc (Miscellaneous data)
 \par \hich\af2\dbch\af31505\loch\f2                 All
 \par 
@@ -798,24 +799,24 @@ abaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept p\hich\af2\dbch\af31505\loch\f2 ipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter uses Word's Sav\hich\af2\dbch\af31505\loch\f2 eAs PDF capability.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microso\hich\af2\dbch\af31505\loch\f2 ft Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter uses Word's SaveAs PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                F\hich\af2\dbch\af31505\loch\f2 alse
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept \hich\af2\dbch\af31505\loch\f2 wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
@@ -1041,7 +1042,7 @@ abaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030033}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https:/go.micr\hich\af2\dbch\af31505\loch\f2 
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003003300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https:/go.micr\hich\af2\dbch\af31505\loch\f2 
 osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
@@ -1055,25 +1056,24 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         NAME: ADDS_Inventory_V3.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 \hich\af2\dbch\af31505\loch\f2 3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2         NAME: AD\hich\af2\dbch\af31505\loch\f2 DS_Inventory_V3.ps1
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5664192 \hich\af2\dbch\af31505\loch\f2 4}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and Michael B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 February }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 \hich\af2\dbch\af31505\loch\f2 20}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 , 2021}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5664192 \hich\af2\dbch\af31505\loch\f2 March 6, 2021}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps\hich\af2\dbch\af31505\loch\f2 1
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a\hich\af2\dbch\af31505\loch\f2 n HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that \hich\af2\dbch\af31505\loch\f2 as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
@@ -1084,7 +1084,7 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\C\hich\af2\dbch\af31505\loch\f2 ompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -1096,9 +1096,9 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that \hich\af2\dbch\af31505\loch\f2 is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
@@ -1106,16 +1106,16 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -ADForest company.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog se\hich\af2\dbch\af31505\loch\f2 rver and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     Compu\hich\af2\dbch\af31505\loch\f2 terName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
@@ -1130,7 +1130,7 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     child.company.tld for the AD Domain.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $\hich\af2\dbch\af31505\loch\f2 Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
@@ -1139,17 +1139,17 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----\hich\af2\dbch\af31505\loch\f2 --------------------- EXAMPLE 5 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest parent.company.tld -ADDomain
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADD\hich\af2\dbch\af31505\loch\f2 S_Inventory_V3.ps1 -ADForest parent.company.tld -ADDomain
 \par \hich\af2\dbch\af31505\loch\f2     child.company.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Because both ADForest and ADDomain are specified, ADDomai\hich\af2\dbch\af31505\loch\f2 n wins and child.company.tld
+\par \hich\af2\dbch\af31505\loch\f2     Because both ADForest and ADDomain are specified, ADDomain wins and child.company.tld
 \par \hich\af2\dbch\af31505\loch\f2     is used for AD Domain.
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 ADForest is set to the value of ADDomain.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 ADForest is set to t\hich\af2\dbch\af31505\loch\f2 he value of ADDomain.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
@@ -1162,25 +1162,25 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -Compu\hich\af2\dbch\af31505\loch\f2 terName DC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -ComputerName DC01
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\C\hich\af2\dbch\af31505\loch\f2 ompany="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for th\hich\af2\dbch\af31505\loch\f2 e Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 The script run}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  remotely on the DC01 domain c\hich\af2\dbch\af31505\loch\f2 ontroller.
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  remotely on the DC01 domain controller.
 \par 
 \par 
 \par 
@@ -1192,20 +1192,20 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values and save}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Car\hich\af2\dbch\af31505\loch\f2 l Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page forma\hich\af2\dbch\af31505\loch\f2 t.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain\hich\af2\dbch\af31505\loch\f2  controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
@@ -1215,10 +1215,9 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Text -ADForest corp.carlwebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
- all default values and save}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
- the document as a formatted text file.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values and save}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  the document as a formatted text \hich\af2\dbch\af31505\loch\f2 file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
@@ -1233,7 +1232,7 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -HTML -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -HTML -ADForest corp.carlweb\hich\af2\dbch\af31505\loch\f2 ster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values and save}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
@@ -1241,10 +1240,10 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of \hich\af2\dbch\af31505\loch\f2 $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a glo\hich\af2\dbch\af31505\loch\f2 bal catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
@@ -1252,7 +1251,7 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\A\hich\af2\dbch\af31505\loch\f2 DDS_Inventory_V3.ps1 -hardware
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -hardware
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 
@@ -1262,12 +1261,12 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 about }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 its hardware.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to\hich\af2\dbch\af31505\loch\f2  the value of $Env:USERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
@@ -1277,22 +1276,22 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -services
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTM\hich\af2\dbch\af31505\loch\f2 L report.
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2  all default values and add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2  additional information for the services running}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2 on }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 each \hich\af2\dbch\af31505\loch\f2 doma\hich\af2\dbch\af31505\loch\f2 in controller.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 each domain controller.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then t\hich\af2\dbch\af31505\loch\f2 he script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
@@ -1315,10 +1314,10 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USER\hich\af2\dbch\af31505\loch\f2 DNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller\hich\af2\dbch\af31505\loch\f2  that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
@@ -1326,14 +1325,14 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS\hich\af2\dbch\af31505\loch\f2 _Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage "Mod" -UserName "Carl Webster" -ComputerName ADDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster
+\par \hich\af2\dbch\af31505\loch\f2     Consu\hich\af2\dbch\af31505\loch\f2 lting" -CoverPage "Mod" -UserName "Carl Webster" -ComputerName ADDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Mod for t\hich\af2\dbch\af31505\loch\f2 he Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
@@ -1345,22 +1344,22 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CN "Carl Webster Consulting"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript\hich\af2\dbch\af31505\loch\f2  .\\ADDS_Inventory_V3.ps1 -MSWord -CN "Carl Webster Consulting"
 \par \hich\af2\dbch\af31505\loch\f2     -CP "Mod" -UN "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl\hich\af2\dbch\af31505\loch\f2  Webster Consulting for the Company Name (alias CN).
-\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (ali\hich\af2\dbch\af31505\loch\f2 as CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of \hich\af2\dbch\af31505\loch\f2 $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global c\hich\af2\dbch\af31505\loch\f2 atalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
@@ -1368,24 +1367,24 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
 \par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2   
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 Street, London, England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C\hich\af2\dbch\af31505\loch\f2 reates a Microsoft Word report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Mi\hich\af2\dbch\af31505\loch\f2 crosoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       +44 1753 276600 for the Company Fax.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1\hich\af2\dbch\af31505\loch\f2 753 276600 for the Company Fax.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain con\hich\af2\dbch\af31505\loch\f2 troller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller tha\hich\af2\dbch\af31505\loch\f2 t is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
@@ -1395,21 +1394,21 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
 \par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Facet -UserName "Dr. Watson" -CompanyEmail
 \par \hich\af2\dbch\af31505\loch\f2     SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for\hich\af2\dbch\af31505\loch\f2  the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the val\hich\af2\dbch\af31505\loch\f2 ue of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 u}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{
@@ -1421,7 +1420,7 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -AddDateTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScrip\hich\af2\dbch\af31505\loch\f2 t >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
@@ -1454,13 +1453,13 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURREN\hich\af2\dbch\af31505\loch\f2 T_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURR\hich\af2\dbch\af31505\loch\f2 ENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the \hich\af2\dbch\af31505\loch\f2 AD Forest.
+\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
@@ -1468,7 +1467,7 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Adds \hich\af2\dbch\af31505\loch\f2 a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 2021-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 The o}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
@@ -1478,7 +1477,7 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------\hich\af2\dbch\af31505\loch\f2 - EXAMPLE 19 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE\hich\af2\dbch\af31505\loch\f2  19 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest corp.carlwebster.com -Folder
 \par \hich\af2\dbch\af31505\loch\f2     \\\\FileServer\\ShareName
@@ -1487,7 +1486,7 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to t\hich\af2\dbch\af31505\loch\f2 he value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value \hich\af2\dbch\af31505\loch\f2 of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
@@ -1499,7 +1498,7 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----------\hich\af2\dbch\af31505\loch\f2 --------------- EXAMPLE 20 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Section Forest
 \par 
@@ -1507,11 +1506,11 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value\hich\af2\dbch\af31505\loch\f2  of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerNam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The report include}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
  only the Forest section.
@@ -1519,15 +1518,15 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE \hich\af2\dbch\af31505\loch\f2 21 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Section groups, misc -ADForest
-\par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com -ServerName PrimaryDC.websterslab\hich\af2\dbch\af31505\loch\f2 .com
+\par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com -ServerName PrimaryDC.websterslab.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com for ADForest.
-\par \hich\af2\dbch\af31505\loch\f2     PrimaryDC.websterslab.com for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     PrimaryDC.websterslab.c\hich\af2\dbch\af31505\loch\f2 om for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The report include}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
  only the Groups and Miscellaneous sections.
@@ -1535,7 +1534,7 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----------------------\hich\af2\dbch\af31505\loch\f2 --- EXAMPLE 22 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -MaxDetails
 \par 
@@ -1544,7 +1543,7 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
 \par \hich\af2\dbch\af31505\loch\f2         DCDNSInfo       = True
 \par \hich\af2\dbch\af31505\loch\f2         GPOInheritance  = True
-\par \hich\af2\dbch\af31505\loch\f2         Hardware        =\hich\af2\dbch\af31505\loch\f2  True
+\par \hich\af2\dbch\af31505\loch\f2         Hardware        = True
 \par \hich\af2\dbch\af31505\loch\f2         IncludeUserInfo = True
 \par \hich\af2\dbch\af31505\loch\f2         Services        = True
 \par 
@@ -1556,8 +1555,8 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer mail.domain.tld -From
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 AD}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
-\hich\af2\dbch\af31505\loch\f2 Admin@domain.tld -To ITGroup@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 AD}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+Admin@domain.tld -To ITGroup@domain.tld
 \par 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server mail.domain.tld, sending from ADAdmin@domain.tld }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
@@ -1568,7 +1567,7 @@ The script uses the default SMTP port 25 and does not use SSL.
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
 If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 
-\hich\af2\dbch\af31505\loch\f2 email, the script prompts }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\hich\af2\dbch\af31505\loch\f2 em\hich\af2\dbch\af31505\loch\f2 ail, the script prompts }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 the user to enter valid credentials.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
@@ -1576,8 +1575,8 @@ If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer mai\hich\af2\dbch\af31505\loch\f2 lrelay.domain.tld -From
-\par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To ITGroup@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer mailrelay.domain.tld -From
+\par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To ITGro\hich\af2\dbch\af31505\loch\f2 up@domain.tld
 \par 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 ***SENDING UNAUTHENTICATED EMAIL***
@@ -1586,23 +1585,23 @@ If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18
 The script uses the email server mailrelay.domain.tld, sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 anonymous@domain.tld and sending to ITGroup@domain.tld.
 \par 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 To s\hich\af2\dbch\af31505\loch\f2 
-end an unauthenticated email using an email relay server requires the From email }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+To send an unauthenticated email using an email relay server r\hich\af2\dbch\af31505\loch\f2 equires the From email }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 account to use the name Anonymous.
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
 The script uses the default SMTP port 25 and does not use SSL.
 \par \tab 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 ***GMAIL/G SUITE SMTP RELAY***
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://suppor
-\hich\af2\dbch\af31505\loch\f2 t.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 {\*\datafield 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+ HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/
-\hich\af2\dbch\af31505\loch\f2 answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 {\*\datafield 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+ HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030030}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
@@ -1612,33 +1611,33 @@ To send an email using a Gmail or g-suite account, you may have to turn ON the "
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
 The script generates an anonymous, secure password for the anonymous@domain.tld }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 account.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 account.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer
-\par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protecti\hich\af2\dbch\af31505\loch\f2 on.outlook.com -UseSSL -From
+\par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
 \par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2 
- HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-applica\hich\af2\dbch\af31505\loch\f2 tion-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
+ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-offi\hich\af2\dbch\af31505\loch\f2 ce-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900460075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 h\hich\af2\dbch\af31505\loch\f2 
-ttps://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000022}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-u\hich\af2\dbch\af31505\loch\f2 
+s/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email \hich\af2\dbch\af31505\loch\f2 server labaddomain-com.mail.protection.outlook.com, sending }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server labaddomain-com.mail.pr\hich\af2\dbch\af31505\loch\f2 otection.outlook.com, sending }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 from SomeEmailAddress@labaddomain.com and sending to ITGroupDL@labaddomain.com.
 \par 
@@ -1653,19 +1652,20 @@ The script uses the default SMTP port 25 and SSL.}{\rtlch\fcs1 \af2\afs18 \ltrch
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server smtp.office365.com on port 587 using SSL, sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the em\hich\af2\dbch\af31505\loch\f2 ail server smtp.office365.com on port 587 using SSL, sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 webster@carlwebster.com and sending to ITGroup@carlwebster.com.
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
 If the current user's credentials are not valid to send an email, the script prompts }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 the user to enter valid credentials.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 the user to enter valid cr\hich\af2\dbch\af31505\loch\f2 edentials.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer \hich\af2\dbch\af31505\loch\f2 smtp.gmail.com -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
@@ -1673,17 +1673,17 @@ If the current user's credentials are not valid to send an email, the script pro
 email using a Gmail or g-suite account, you may have to turn ON}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2 the "Less }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 secure app access" option on your account.
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   *** NOTE ***
+\par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server smtp.gmail.com on port 587 using SSL, sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 webster@gmail.com and sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 webster\hich\af2\dbch\af31505\loch\f2 @gmail.com and sending to ITGroup@carlwebster.com.
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
 If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 
 \hich\af2\dbch\af31505\loch\f2 email, the script prompts }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 th\hich\af2\dbch\af31505\loch\f2 e \hich\af2\dbch\af31505\loch\f2 user to enter valid credentials.}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 the user to enter valid credentials.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
@@ -1805,8 +1805,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000005082
-8a468b07d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000c0a9
+2f37da12d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/ADDS_Inventory_V3_ReadMe.rtf
+++ b/ADDS_Inventory_V3_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -49,54 +49,52 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \sbasedon10 \sunhideused \styrsid11488686 Hyperlink;}{\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
 \snext19 \sqformat \spriority1 \styrsid10945524 No Spacing;}{\*\cs20 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf19 \sbasedon10 \styrsid15355254 FollowedHyperlink;}{\*\cs21 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf15\chshdng0\chcfpat0\chcbpat20 
 \sbasedon10 \ssemihidden \sunhideused \styrsid15166704 Unresolved Mention;}}{\*\listtable{\list\listtemplateid645948268\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li6480\lin6480 }{\listname ;}\listid319386001}{\list\listtemplateid-393728524\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
-\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
-\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689
-\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
-\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689
-\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
-\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid1724937716}{\list\listtemplateid-154213762\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
-\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0
-{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li6480\lin6480 }{\listname ;}\listid1818835589}{\list\listtemplateid-183201164\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
-\levelfollow0\levelstartat0\levelspace0\levelindent0{\leveltext\leveltemplateid2071627316\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
-\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
-\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0
-{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589\listoverridecount0\ls2}
+\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698713
+\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715
+\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703
+\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713
+\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715
+\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703
+\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713
+\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715
+\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid319386001}{\list\listtemplateid-393728524\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
+\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 
+\fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23
+\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1724937716}{\list\listtemplateid-154213762\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
+\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698715
+\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}
+\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 
+\ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-180\li6480\lin6480 }{\listname ;}\listid1818835589}{\list\listtemplateid-183201164\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace0\levelindent0{\leveltext\leveltemplateid2071627316
+\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}
+\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }
+{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23
+\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693
+\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589\listoverridecount0\ls2}
 {\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1818835589\listoverridecount9{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}
 {\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat
 \levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid407474\rsid412309\rsid667579\rsid741398\rsid854968\rsid880017\rsid1520287\rsid1529376\rsid1780561\rsid2638156\rsid2710199
 \rsid2974686\rsid3342358\rsid3477011\rsid3828116\rsid3830441\rsid4281248\rsid4467197\rsid4483701\rsid4945864\rsid5315553\rsid5664192\rsid5720771\rsid5767175\rsid5849890\rsid5904556\rsid6038932\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7681868
 \rsid7695940\rsid8013811\rsid8220290\rsid8793422\rsid9243658\rsid9252303\rsid9512169\rsid9727541\rsid9838801\rsid9848053\rsid10101060\rsid10290913\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11433897\rsid11488686\rsid11602030
-\rsid12197314\rsid12322737\rsid12343757\rsid12588820\rsid12675704\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13511313\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14176547\rsid14566444\rsid14697282\rsid14893653
-\rsid14952143\rsid15166704\rsid15355254\rsid15760967\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}
-{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo3\dy6\hr16\min44}{\version59}{\edmins671}{\nofpages23}{\nofwords6815}{\nofchars38847}{\nofcharsws45571}{\vern17}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
-\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid12197314\rsid12322737\rsid12343757\rsid12588820\rsid12675704\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13511313\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14168903\rsid14176547\rsid14566444\rsid14697282
+\rsid14893653\rsid14952143\rsid15166704\rsid15355254\rsid15760967\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info
+{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo3\dy24\hr7\min10}{\version60}{\edmins674}{\nofpages23}{\nofwords6820}{\nofchars38874}{\nofcharsws45603}{\vern21}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/w
+ordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwNK4FAJrt6aktAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwNKkFAF17qOYtAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -273,19 +271,19 @@ t one Windows 7 SP1 or later computer with the Remote Server Administration Tool
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 
 HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100630065003500
-65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab0003493200}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab000349320044}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 R\hich\af37\dbch\af31505\loch\f37 SAT for Windows 8 is available here, }
 {\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab0003880029}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab000388002900}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004900}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300490044}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -293,9 +291,9 @@ HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12916989 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c00000065000000030200060057d1}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid13858952 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952\charrsid13858952 
-
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c00000065000000030200060057d100}}}{\fldrslt {\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid13858952 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid13858952\charrsid13858952 
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
 \par \hich\af37\dbch\af31505\loch\f37 Th}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12322737 \hich\af37\dbch\af31505\loch\f37 e V3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37  scrip
 \hich\af37\dbch\af31505\loch\f37 t was developed using Windows Server 20}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12322737 
@@ -368,7 +366,8 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par \hich\af2\dbch\af31505\loch\f2     C:\\webster\\ADDS_Inventory_V3.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
-\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft Active Directory Forest.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft Active Directory Forest}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14168903 \hich\af2\dbch\af31505\loch\f2  or Domain}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 .
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
@@ -389,11 +388,14 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a M\hich\af2\dbch\af31505\loch\f2 icrosoft Active Directory Forest using Microsoft
-\par \hich\af2\dbch\af31505\loch\f2     PowerShell, Word, plain text, or HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a M\hich\af2\dbch\af31505\loch\f2 icrosoft Active Directory Forest }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14168903 \hich\af2\dbch\af31505\loch\f2 or Domain }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 using }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14168903 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 Microsoft}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14168903 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 PowerShell, Word, plain text, or HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Word or PDF document, text, or HTML file named after the Active Directory
-\par \hich\af2\dbch\af31505\loch\f2     Forest.
+\par \hich\af2\dbch\af31505\loch\f2     Forest}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14168903 \hich\af2\dbch\af31505\loch\f2  or \hich\af2\dbch\af31505\loch\f2 Domain}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 .
+
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Version 3.0 changes the default output report from Word to\hich\af2\dbch\af31505\loch\f2  HTML.
 \par 
@@ -444,38 +446,38 @@ me Server and AD database, log file, and
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100630065003500
-65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab0003002600}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebst\hich\af2\dbch\af31505\loch\f2 er.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 
+65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab000300260044}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebs\hich\af2\dbch\af31505\loch\f2 ter.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab0003003800}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab000300380043}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8.1
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.\hich\af2\dbch\af31505\loch\f2 
-sharefile.com/d-s37209afb73dc48f497745924ed854226" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster\hich\af2\dbch\af31505\loch\f2 
+.sharefile.com/d-s37209afb73dc48f497745924ed854226" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003c43244}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed\hich\af2\dbch\af31505\loch\f2 854226}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003c4324444}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924e\hich\af2\dbch\af31505\loch\f2 d854226}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 10
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003003000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030030005f}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
 \par \hich\af2\dbch\af31505\loch\f2     -ADDomain <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory domain object by providing one of the following
-\par \hich\af2\dbch\af31505\loch\f2         property values. The identifier in p\hich\af2\dbch\af31505\loch\f2 arentheses is the LDAP display name for the
+\par \hich\af2\dbch\af31505\loch\f2         property values. The identifier i\hich\af2\dbch\af31505\loch\f2 n parentheses is the LDAP display name for the
 \par \hich\af2\dbch\af31505\loch\f2         attribute. All values are for the domainDNS object that represents the domain.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Distinguished Name
@@ -1042,8 +1044,8 @@ abaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003003300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https:/go.micr\hich\af2\dbch\af31505\loch\f2 
-osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 ).
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300330035}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
@@ -1059,13 +1061,14 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par \hich\af2\dbch\af31505\loch\f2         NAME: AD\hich\af2\dbch\af31505\loch\f2 DS_Inventory_V3.ps1
 \par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5664192 \hich\af2\dbch\af31505\loch\f2 4}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and Michael B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5664192 \hich\af2\dbch\af31505\loch\f2 March 6, 2021}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5664192 \hich\af2\dbch\af31505\loch\f2 March }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14168903 \hich\af2\dbch\af31505\loch\f2 24}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5664192 \hich\af2\dbch\af31505\loch\f2 , 2021}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a\hich\af2\dbch\af31505\loch\f2 n HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HT\hich\af2\dbch\af31505\loch\f2 ML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
@@ -1073,7 +1076,7 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 fo\hich\af2\dbch\af31505\loch\f2 r ComputerName.
 \par 
 \par 
 \par 
@@ -1085,7 +1088,7 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
@@ -1169,13 +1172,13 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for th\hich\af2\dbch\af31505\loch\f2 e Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15760967 
@@ -1296,7 +1299,7 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   -------------------------- EXAMPLE 12 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -DCDNSInfo
 \par 
@@ -1307,7 +1310,7 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \hich\af2\dbch\af31505\loch\f2  all default values and add}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2  additional information for each domain controller}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2 about }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 its DNS IP configuration.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 i\hich\af2\dbch\af31505\loch\f2 ts DNS IP configuration.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     An extra section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 is}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
  added to the end of the report.
@@ -1315,7 +1318,7 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller\hich\af2\dbch\af31505\loch\f2  that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller \hich\af2\dbch\af31505\loch\f2 that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1780561 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
@@ -1326,7 +1329,7 @@ osoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2     Consu\hich\af2\dbch\af31505\loch\f2 lting" -CoverPage "Mod" -UserName "Carl Webster" -ComputerName ADDC01
+\par \hich\af2\dbch\af31505\loch\f2     Consul\hich\af2\dbch\af31505\loch\f2 ting" -CoverPage "Mod" -UserName "Carl Webster" -ComputerName ADDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
@@ -1459,7 +1462,7 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
+\par \hich\af2\dbch\af31505\loch\f2     corp.carlwe\hich\af2\dbch\af31505\loch\f2 bster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
@@ -1467,7 +1470,7 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds \hich\af2\dbch\af31505\loch\f2 a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time sta\hich\af2\dbch\af31505\loch\f2 mp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 2021-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 The o}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
@@ -1477,7 +1480,7 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE\hich\af2\dbch\af31505\loch\f2  19 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest corp.carlwebster.com -Folder
 \par \hich\af2\dbch\af31505\loch\f2     \\\\FileServer\\ShareName
@@ -1486,7 +1489,7 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value \hich\af2\dbch\af31505\loch\f2 of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNS\hich\af2\dbch\af31505\loch\f2 DOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
@@ -1498,7 +1501,7 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     --------------\hich\af2\dbch\af31505\loch\f2 ------------ EXAMPLE 20 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Section Forest
 \par 
@@ -1506,7 +1509,7 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value\hich\af2\dbch\af31505\loch\f2  of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDO\hich\af2\dbch\af31505\loch\f2 MAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2  that as the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \hich\af2\dbch\af31505\loch\f2 value }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
@@ -1518,7 +1521,7 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE \hich\af2\dbch\af31505\loch\f2 21 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Section groups, misc -ADForest
 \par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com -ServerName PrimaryDC.websterslab.com
@@ -1526,7 +1529,7 @@ utput filename }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hi
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com for ADForest.
-\par \hich\af2\dbch\af31505\loch\f2     PrimaryDC.websterslab.c\hich\af2\dbch\af31505\loch\f2 om for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     PrimaryDC.websterslab.com for ComputerNam\hich\af2\dbch\af31505\loch\f2 e.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The report include}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
  only the Groups and Miscellaneous sections.
@@ -1596,12 +1599,12 @@ The script uses the default SMTP port 25 and does not use SSL.
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 
  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300005f}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2 
  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030030}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003003068}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
@@ -1611,33 +1614,33 @@ To send an email using a Gmail or g-suite account, you may have to turn ON the "
 \par 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 
 The script generates an anonymous, secure password for the anonymous@domain.tld }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 account.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5315553\charrsid5315553 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 account.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5315553 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer
-\par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
+\par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protecti\hich\af2\dbch\af31505\loch\f2 on.outlook.com -UseSSL -From
 \par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 \hich\af2\dbch\af31505\loch\f2 
- HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-offi\hich\af2\dbch\af31505\loch\f2 ce-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
+ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-applica\hich\af2\dbch\af31505\loch\f2 tion-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900460075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000022}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-u\hich\af2\dbch\af31505\loch\f2 
-s/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5315553\charrsid5315553 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab000300002230}}}{\fldrslt {
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5315553\charrsid5315553 \hich\af2\dbch\af31505\loch\f2 
+https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5315553\charrsid5315553 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14952143 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email server labaddomain-com.mail.pr\hich\af2\dbch\af31505\loch\f2 otection.outlook.com, sending }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
+\f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 The script uses the email\hich\af2\dbch\af31505\loch\f2  server labaddomain-com.mail.protection.outlook.com, sending }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143 
 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14952143\charrsid14952143 \hich\af2\dbch\af31505\loch\f2 from SomeEmailAddress@labaddomain.com and sending to ITGroupDL@labaddomain.com.
 \par 
@@ -1805,8 +1808,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000c0a9
-2f37da12d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000009073
+baa1a620d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/ADDS_V3_Script_ChangeLog.txt
+++ b/ADDS_V3_Script_ChangeLog.txt
@@ -8,15 +8,25 @@
 #@essentialexch on Twitter
 #https://www.essential.exchange/blog/
 
-#Version 3.04
+#Version 3.04 24-Mar-2021
+#	Change the wording for schema extensions from "Just because a schema extension is Present does not mean it is in use."
+#		To "Just because a schema extension is Present does not mean that the product is in use."
 #	Only process and output Foreign Security Principal data for the Root Domain
+#	Only process the Appendix Domain Controller DNS Info if -DCDNSInfo is true. No need for an empty table and Appendix otherwise
+#	Removed a few warnings from the console output that were not warnings
 #	The following fixes are for running the script in a Forest with multiple domains
-#		When creating the array that contains all domain controllers, don't sort at that point as it changed the Type of the arraylist after the first domain was processed
+#		When creating the array that contains all domain controllers, don't sort after each domain as sorting changed the Type of the arraylist after the first domain was processed
 #			This caused the three Appendixes to only contain the data for the DCs in the first domain
 #		When outputting domain controllers, sort the DCs by domain name and DC name
 #			Put the DCs in domain name order, don't put every DC in the Root domain
 #			Change the header to reflect the actual domain name
 #		When retrieving Inherited GPOs, add the Domain name to the cmdlet
+#		When running in a child or tree domain, only the domain entered was used when calculating the number of domains in the forest
+#			That is now fixed
+#		When running in a child or tree domain and using -ADForest, compare the root domain's name to the name entered for -ADForest
+#			If they are not the same, abort the script and state to rerun the script with -ADDomain and not -ADForest
+#	Updated the help text
+#	Updated the ReadMe file
 
 #Version 3.03 22-Feb-2021
 #	Added a Try/Catch and -LDAPFilter when checking for the Exchange schema attributes to suppress the error if Exchange is not installed

--- a/ADDS_V3_Script_ChangeLog.txt
+++ b/ADDS_V3_Script_ChangeLog.txt
@@ -8,6 +8,16 @@
 #@essentialexch on Twitter
 #https://www.essential.exchange/blog/
 
+#Version 3.04
+#	Only process and output Foreign Security Principal data for the Root Domain
+#	The following fixes are for running the script in a Forest with multiple domains
+#		When creating the array that contains all domain controllers, don't sort at that point as it changed the Type of the arraylist after the first domain was processed
+#			This caused the three Appendixes to only contain the data for the DCs in the first domain
+#		When outputting domain controllers, sort the DCs by domain name and DC name
+#			Put the DCs in domain name order, don't put every DC in the Root domain
+#			Change the header to reflect the actual domain name
+#		When retrieving Inherited GPOs, add the Domain name to the cmdlet
+
 #Version 3.03 22-Feb-2021
 #	Added a Try/Catch and -LDAPFilter when checking for the Exchange schema attributes to suppress the error if Exchange is not installed
 #	Added Domain SID to the Domain Information section


### PR DESCRIPTION
#Version 3.04 24-Mar-2021
#	Change the wording for schema extensions from "Just because a schema extension is Present does not mean it is in use."
#		To "Just because a schema extension is Present does not mean that the product is in use."
#	Only process and output Foreign Security Principal data for the Root Domain
#	Only process the Appendix Domain Controller DNS Info if -DCDNSInfo is true. No need for an empty table and Appendix otherwise
#	Removed a few warnings from the console output that were not warnings
#	The following fixes are for running the script in a Forest with multiple domains
#		When creating the array that contains all domain controllers, don't sort after each domain as sorting changed the Type of the arraylist after the first domain was processed
#			This caused the three Appendixes to only contain the data for the DCs in the first domain
#		When outputting domain controllers, sort the DCs by domain name and DC name
#			Put the DCs in domain name order, don't put every DC in the Root domain
#			Change the header to reflect the actual domain name
#		When retrieving Inherited GPOs, add the Domain name to the cmdlet
#		When running in a child or tree domain, only the domain entered was used when calculating the number of domains in the forest
#			That is now fixed
#		When running in a child or tree domain and using -ADForest, compare the root domain's name to the name entered for -ADForest
#			If they are not the same, abort the script and state to rerun the script with -ADDomain and not -ADForest
#	Updated the help text
#	Updated the ReadMe file