### PR TITLE
3.07

### DIFF
--- a/ADDS_Inventory_V3_ReadMe.rtf
+++ b/ADDS_Inventory_V3_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -85,15 +85,15 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589\listoverridecount0\ls2}
 {\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1818835589\listoverridecount9{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}
 {\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat
-\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid208880\rsid407474\rsid412309\rsid667579\rsid741398\rsid854968\rsid880017\rsid1520287\rsid1529376\rsid1778922\rsid1780561
-\rsid2374340\rsid2638156\rsid2710199\rsid2974686\rsid3342358\rsid3477011\rsid3828116\rsid3830441\rsid4269799\rsid4281248\rsid4467197\rsid4483701\rsid4945864\rsid5315553\rsid5664192\rsid5720771\rsid5767175\rsid5849890\rsid5904556\rsid6038932\rsid6095241
-\rsid6179101\rsid6508857\rsid6508924\rsid6626993\rsid7681868\rsid7695940\rsid8013811\rsid8220290\rsid8793422\rsid9243658\rsid9252303\rsid9512169\rsid9727541\rsid9838801\rsid9848053\rsid10101060\rsid10290913\rsid10902102\rsid10945524\rsid11337799
-\rsid11370278\rsid11430143\rsid11433897\rsid11488686\rsid11602030\rsid11867194\rsid12197314\rsid12322737\rsid12343757\rsid12588820\rsid12675704\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13511313\rsid13532324\rsid13725463
-\rsid13791374\rsid13858952\rsid13987238\rsid14168903\rsid14176547\rsid14566444\rsid14697282\rsid14893653\rsid14952143\rsid15166704\rsid15355254\rsid15760967\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0
-\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo7\dy27\hr5\min45}{\version67}{\edmins690}{\nofpages23}{\nofwords6846}{\nofchars39025}
-{\nofcharsws45780}{\vern27}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid208880\rsid407474\rsid412309\rsid667579\rsid741398\rsid817497\rsid854968\rsid880017\rsid1520287\rsid1529376\rsid1778922
+\rsid1780561\rsid2374340\rsid2638156\rsid2710199\rsid2974686\rsid3342358\rsid3477011\rsid3828116\rsid3830441\rsid4269799\rsid4281248\rsid4467197\rsid4483701\rsid4945864\rsid5315553\rsid5664192\rsid5720771\rsid5767175\rsid5849890\rsid5904556\rsid6038932
+\rsid6095241\rsid6179101\rsid6508857\rsid6508924\rsid6626993\rsid7681868\rsid7695940\rsid8013811\rsid8220290\rsid8793422\rsid9243658\rsid9252303\rsid9512169\rsid9727541\rsid9838801\rsid9848053\rsid10101060\rsid10290913\rsid10902102\rsid10945524
+\rsid11337799\rsid11370278\rsid11430143\rsid11433897\rsid11488686\rsid11602030\rsid11867194\rsid12197314\rsid12322737\rsid12343757\rsid12588820\rsid12675704\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13511313\rsid13532324
+\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14168903\rsid14176547\rsid14566444\rsid14697282\rsid14893653\rsid14952143\rsid15166704\rsid15355254\rsid15760967\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0
+\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo8\dy31\hr4\min57}{\version68}{\edmins697}{\nofpages24}{\nofwords7005}{\nofchars39932}
+{\nofcharsws46844}{\vern31}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwtKwFABAFBlMtAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
@@ -271,18 +271,19 @@ t one Windows 7 SP1 or later computer with the Remote Server Administration Tool
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 
 HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100630065003500
-65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab000349320044000000009400ec}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab000349320044000000009400ec00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab000388002900ff0000002e8f00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab000388002900ff0000002e8f0000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration\hich\af37\dbch\af31505\loch\f37  Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004900440000003b008faa}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004900440000003b008faa00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -290,7 +291,7 @@ HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12916989 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c00000065000000030200060057d100007f000000802c}}}{\fldrslt {
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c00000065000000030200060057d100007f000000802c5b}}}{\fldrslt {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid13858952 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid13858952\charrsid13858952 
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
@@ -361,42 +362,40 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid10945524 \hich\af43\dbch\af31505\loch\f43 Help Text
 \par }\pard\plain \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10945524 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
 \ltrch\fcs0 \insrsid10945524 
-\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid1778922 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 PS C:\\Webster> get-help .\\
-ADDS_Inventory_V3.ps1 -full
-\par 
-\par \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid817497 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 NAME
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2 C:\\PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \\\hich\af2\dbch\af31505\loch\f2 
+ADDS_Inventory_V3.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
 \par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft Active Directory Forest or Domain.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\ADDS_Inventory_V3.ps1 [-ADDomain <String>] [-ADForest <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13532324 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-MaxDetails] [-HTML] [\hich\af2\dbch\af31505\loch\f2 
--Text] [-AddDateTime] [-CompanyName }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13532324 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-Folder <String>] [-Log] [-ScriptInfo] [-DCDNSInfo] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid13532324 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 [-GPOInheritance] [-Hardware] [-IncludeUserInfo] [-Section <String[]>] [-Services] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid13532324 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 [-MSWord]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13532324 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 [-PDF] [-CompanyAddress <String>] [-Compan\hich\af2\dbch\af31505\loch\f2 yEmail <String>] [-CompanyFax }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid13532324 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid13532324 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 [-SmtpPort <Int32>] [-SmtpServer <String>] [-SuperVerbose] [-From <String>] [-To }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid13532324 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 <String>] [-UseSSL] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2 C:\\PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \\\hich\af2\dbch\af31505\loch\f2 
+ADDS_Inventory_V3.ps1 [-ADDomain <String>] [-ADForest <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-MaxDetails] [-HTML] [-Text] [-AddDateTime] [-CompanyName }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid817497 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 <\hich\af2\dbch\af31505\loch\f2 
+String>] [-Dev] [-Folder <String>] [-Log] [-ScriptInfo] [-ReportFooter] [-DCDNSInfo] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 [-GPOInheritance] [-Hardware] [-IncludeUserInfo] [-Section <String[]>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2     [-Services] [-MSWord] [-PDF] [-CompanyAddress <String>] [-CompanyEmail <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 
+
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 [-CompanyFax <S\hich\af2\dbch\af31505\loch\f2 tring>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 <String>] [-SmtpPort <Int32>] [-SmtpServer <String>] [-SuperVerbose] [-From <String>] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid817497 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 [-To <String>] [-UseSSL] [<CommonParameters>]
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2 DESCRIPTI\hich\af2\dbch\af31505\loch\f2 ON
-\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft Active Directory Forest or Domain using
+\par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Micros\hich\af2\dbch\af31505\loch\f2 oft Active Directory Forest or Domain using
 \par \hich\af2\dbch\af31505\loch\f2     Microsoft PowerShell, Word, plain text, or HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Word or PDF document, text, or HTML file named after the Active Directory
 \par \hich\af2\dbch\af31505\loch\f2     Forest or Domain.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Version 3.0 changes the default output report from Word to HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Version 3.0 changes the default output repo\hich\af2\dbch\af31505\loch\f2 rt from Word to HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF document includes a Cover Page, Table of Contents, and Footer.
 \par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
@@ -413,67 +412,67 @@ ADDS_Inventory_V3.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Spanish
 \par \hich\af2\dbch\af31505\loch\f2         Swedish
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script requires at least PowerShell version 3 but runs best in version \hich\af2\dbch\af31505\loch\f2 5.
+\par \hich\af2\dbch\af31505\loch\f2     The script requires at least PowerShell version 3 but runs best in version 5.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script outputs in Text and HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script out\hich\af2\dbch\af31505\loch\f2 puts in Text and HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a domain controller. This script was developed
 \par \hich\af2\dbch\af31505\loch\f2     and run from a Windows 10 VM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     While most of the script can run with a non\hich\af2\dbch\af31505\loch\f2 -admin account, there are some features
-\par \hich\af2\dbch\af31505\loch\f2     that will not or may not work without domain admin or enterprise admin rights.
+\par \hich\af2\dbch\af31505\loch\f2     While most of the script can run with a non-admin account, there are some features
+\par \hich\af2\dbch\af31505\loch\f2     that will not or \hich\af2\dbch\af31505\loch\f2 may not work without domain admin or enterprise admin rights.
 \par \hich\af2\dbch\af31505\loch\f2     The Hardware and Services parameters require domain admin privileges.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script does gathering of information on Time Serve\hich\af2\dbch\af31505\loch\f2 r and AD database, log file, and
-\par \hich\af2\dbch\af31505\loch\f2     SYSVOL locations. Those require access to the registry on each domain controller, which
+\par \hich\af2\dbch\af31505\loch\f2     The script does gathering of information on Time Server and AD database, log file, and
+\par \hich\af2\dbch\af31505\loch\f2     SYSVOL locations. Those \hich\af2\dbch\af31505\loch\f2 require access to the registry on each domain controller, which
 \par \hich\af2\dbch\af31505\loch\f2     means the script should now always be run from an elevated PowerShell session with an
-\par \hich\af2\dbch\af31505\loch\f2     account with a minimum of domain admi\hich\af2\dbch\af31505\loch\f2 n rights.
+\par \hich\af2\dbch\af31505\loch\f2     account with a minimum of domain admin rights.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Running the script in a forest with multiple domains requires Enterprise Admin rights.
+\par \hich\af2\dbch\af31505\loch\f2     Running the script in a forest with multiple d\hich\af2\dbch\af31505\loch\f2 omains requires Enterprise Admin rights.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The count of all users may not be accurate if the user running the script does not have
 \par \hich\af2\dbch\af31505\loch\f2     the necessary permissions on all user objects.  In that case, there may be user accounts
 \par \hich\af2\dbch\af31505\loch\f2     classified as "unknown".
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To run the script from a workstation,\hich\af2\dbch\af31505\loch\f2  RSAT is required.
+\par \hich\af2\dbch\af31505\loch\f2     To run the script from a workstation, RSAT is required.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13532324 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24" }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13532324 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100630065003500
-65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\cs18\f2\fs18\ul\cf2\insrsid1778922\charrsid13532324 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid1778922\charrsid1778922 
+65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid817497\charrsid817497 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13532324 \hich\af2\dbch\af31505\loch\f2  HY\hich\af2\dbch\af31505\loch\f2 
-PERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13532324 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Too\hich\af2\dbch\af31505\loch\f2 ls for Windows 8
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab0003002eec00}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\cs18\f2\fs18\ul\cf2\insrsid1778922\charrsid13532324 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/\hich\af2\dbch\af31505\loch\f2 d-s791075d451fc415ca83ec8958b385a95}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid817497\charrsid817497 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8.1
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13532324 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226" }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13532324 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb
+\hich\af2\dbch\af31505\loch\f2 73dc48f497745924ed854226"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000fa}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\cs18\f2\fs18\ul\cf2\insrsid1778922\charrsid13532324 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid1778922\charrsid1778922 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid817497\charrsid817497 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 10
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13532324 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/downl\hich\af2\dbch\af31505\loch\f2 
-oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13532324 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administ\hich\af2\dbch\af31505\loch\f2 ration Tools for Windows 10
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK \hich\af2\dbch\af31505\loch\f2 
+"http://www.microsoft.com/en-us/download/details.aspx?id=45520"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300a400fa}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid1778922\charrsid13532324 
-\hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 
+\hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
-\par \hich\af2\dbch\af31505\loch\f2     -ADDomain <S\hich\af2\dbch\af31505\loch\f2 tring>
+\par \hich\af2\dbch\af31505\loch\f2     -ADDomain <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory domain object by providing one of the following
-\par \hich\af2\dbch\af31505\loch\f2         property values. The identifier in parentheses is the LDAP display name for the
-\par \hich\af2\dbch\af31505\loch\f2         attribute. All values are for the domainDNS object that represents \hich\af2\dbch\af31505\loch\f2 the domain.
+\par \hich\af2\dbch\af31505\loch\f2         property values. The identif\hich\af2\dbch\af31505\loch\f2 ier in parentheses is the LDAP display name for the
+\par \hich\af2\dbch\af31505\loch\f2         attribute. All values are for the domainDNS object that represents the domain.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Distinguished Name
 \par 
@@ -481,7 +480,7 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         GUID (objectGUID)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Example: b147a813-9938-4a89-bc93-58a0d36c41c3
+\par \hich\af2\dbch\af31505\loch\f2         Example: b147\hich\af2\dbch\af31505\loch\f2 a813-9938-4a89-bc93-58a0d36c41c3
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Security Identifier (objectSid)
 \par 
@@ -500,13 +499,13 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       \hich\af2\dbch\af31505\loch\f2 false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ADForest <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Director\hich\af2\dbch\af31505\loch\f2 y forest object by providing one of the following
+\par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory forest object by providing one of the following
 \par \hich\af2\dbch\af31505\loch\f2         attribute values.
-\par \hich\af2\dbch\af31505\loch\f2         The identifier in parentheses is the LDAP display name for the attribute.
+\par \hich\af2\dbch\af31505\loch\f2         The identifier in parentheses is the LDAP display name for the \hich\af2\dbch\af31505\loch\f2 attribute.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Fully qualified domain name
 \par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain.com
@@ -517,27 +516,27 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2         NetBIOS name
 \par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain
 \par 
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Default value is $Env:USERDNSDOMAIN
+\par \hich\af2\dbch\af31505\loch\f2         Default value is $Env:USERDNSDOMAIN
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If both ADForest and ADDomain are specified, ADDomain takes precedence.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?             \hich\af2\dbch\af31505\loch\f2        false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:USERDNS\hich\af2\dbch\af31505\loch\f2 DOMAIN
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:USERDNSDOMAIN
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ComputerName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies which domain controller to use to run the script against.
-\par \hich\af2\dbch\af31505\loch\f2         If ADForest is a trusted forest, then ComputerName \hich\af2\dbch\af31505\loch\f2 is required to detect the
+\par \hich\af2\dbch\af31505\loch\f2         Specifies which domain\hich\af2\dbch\af31505\loch\f2  controller to use to run the script against.
+\par \hich\af2\dbch\af31505\loch\f2         If ADForest is a trusted forest, then ComputerName is required to detect the
 \par \hich\af2\dbch\af31505\loch\f2         existence of ADForest.
 \par \hich\af2\dbch\af31505\loch\f2         ComputerName can be entered as the NetBIOS name, FQDN, localhost, or IP Address.
-\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and used.
-\par \hich\af2\dbch\af31505\loch\f2         If entered as an IP \hich\af2\dbch\af31505\loch\f2 address, an attempt is made to determine and use the actual
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    If entered as localhost, the actual computer name is determined and used.
+\par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and use the actual
 \par \hich\af2\dbch\af31505\loch\f2         computer name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ServerName.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is $Env:USERDNSDOMAIN
+\par \hich\af2\dbch\af31505\loch\f2         Default \hich\af2\dbch\af31505\loch\f2 value is $Env:USERDNSDOMAIN
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -545,28 +544,28 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -MaxDetails [<SwitchPar\hich\af2\dbch\af31505\loch\f2 ameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -MaxDetails [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds maximum detail to the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is the same as using the following parameters:
 \par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo
-\par \hich\af2\dbch\af31505\loch\f2                 GPOInheritance
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              GPOInheritance
 \par \hich\af2\dbch\af31505\loch\f2                 Hardware
 \par \hich\af2\dbch\af31505\loch\f2                 IncludeUserInfo
 \par \hich\af2\dbch\af31505\loch\f2                 Services
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      WARNING: Using this parameter can create an extremely large report and
+\par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extremely large report and
 \par \hich\af2\dbch\af31505\loch\f2         can take a very long time to run.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter \hich\af2\dbch\af31505\loch\f2 has an alias of MAX.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -HTML [<Switch\hich\af2\dbch\af31505\loch\f2 Parameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         HTML is now the default report format.
@@ -574,26 +573,26 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                  \hich\af2\dbch\af31505\loch\f2   named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is \hich\af2\dbch\af31505\loch\f2 disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    n\hich\af2\dbch\af31505\loch\f2 amed
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [\hich\af2\dbch\af31505\loch\f2 <SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date timestamp to the end of the file name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The timestamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2         The timestamp is\hich\af2\dbch\af31505\loch\f2  in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2         June 1, 2021 at 6PM is 2021-06-01_1800.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2021-06-01_1800.docx (or .pdf).
@@ -603,30 +602,28 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fa\hich\af2\dbch\af31505\loch\f2 lse
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Word Cover Page or the Forest Information section for }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 HTM\hich\af2\dbch\af31505\loch\f2 L and Text.
+\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Word Cover Page or the Forest Information section for
+\par \hich\af2\dbch\af31505\loch\f2         HTML and Text.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Default value for Word output is contained in
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\C\hich\af2\dbch\af31505\loch\f2 ompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
-\par \hich\af2\dbch\af31505\loch\f2         on the computer runnin\hich\af2\dbch\af31505\loch\f2 g the script.
+\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         For Word output, if either registry key does not exist and this parameter is not }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 specified, the report }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 
-\hich\af2\dbch\af31505\loch\f2 does}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2  not contain a Company Name on the cover page.
+\par \hich\af2\dbch\af31505\loch\f2         For Word output, if either registry key does not exist an\hich\af2\dbch\af31505\loch\f2 d this parameter is not
+\par \hich\af2\dbch\af31505\loch\f2         specified, the report does not contain a Company Name on the cover page.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         For HTML and Text\hich\af2\dbch\af31505\loch\f2  output, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 \hich\af2\dbch\af31505\loch\f2 the Forest Information section }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid13532324 \hich\af2\dbch\af31505\loch\f2 does}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 \hich\af2\dbch\af31505\loch\f2  not contain the Company 
-\par \hich\af2\dbch\af31505\loch\f2         Name if this parameter is not specified}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 .
+\par \hich\af2\dbch\af31505\loch\f2         For HTML and Text output, the Forest Information section does not contain the Company
+\par \hich\af2\dbch\af31505\loch\f2         Name if this parameter is not specified.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -636,24 +633,24 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
 \par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is u\hich\af2\dbch\af31505\loch\f2 sed when the script developer requests more troubleshooting data.
-\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script runs.
+\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder\hich\af2\dbch\af31505\loch\f2  from where the script runs.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept p\hich\af2\dbch\af31505\loch\f2 ipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
@@ -663,14 +660,40 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard character\hich\af2\dbch\af31505\loch\f2 s?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to\hich\af2\dbch\af31505\loch\f2  a text file.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script runs.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This paramete\hich\af2\dbch\af31505\loch\f2 r has an alias of SI.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?           \hich\af2\dbch\af31505\loch\f2          named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -ReportFooter [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Outputs a footer section at the end of the report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This \hich\af2\dbch\af31505\loch\f2 parameter has an alias of RF.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Report Footer
+\par \hich\af2\dbch\af31505\loch\f2                 Report information:
+\par \hich\af2\dbch\af31505\loch\f2                         Created with: <Script Name> - Release Date: <Script Release Date>
+\par \hich\af2\dbch\af31505\loch\f2                         Started on <Date Time in Local Format>
+\par \hich\af2\dbch\af31505\loch\f2                         Elapsed time: nn days, nn hours, nn minutes, nn.nn seconds
+\par \hich\af2\dbch\af31505\loch\f2                         Ran from domain <Domain Name> by user <Username>
+\par \hich\af2\dbch\af31505\loch\f2                         Ran from the folder <Folder Name>
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Script Name and Script Release da\hich\af2\dbch\af31505\loch\f2 te are script-specific variables.
+\par \hich\af2\dbch\af31505\loch\f2         Start Date Time in Local Format is a script variable.
+\par \hich\af2\dbch\af31505\loch\f2         Elapsed time is a calulated value.
+\par \hich\af2\dbch\af31505\loch\f2         Domain Name is $env:USERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2         Username is $env:USERNAME.
+\par \hich\af2\dbch\af31505\loch\f2         Folder Name is a script variabl\hich\af2\dbch\af31505\loch\f2 e.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -678,18 +701,18 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -DCDNSInfo [<\hich\af2\dbch\af31505\loch\f2 SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather, for each domain controller, the IP Address, and each DNS server
+\par \hich\af2\dbch\af31505\loch\f2     -DCDNSInfo [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Use WMI to gather, for each domain controller, the IP Address, and each DNS server
 \par \hich\af2\dbch\af31505\loch\f2         configured.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script to run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission \hich\af2\dbch\af31505\loch\f2 to retrieve hardware information (i.e., Domain
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardwar\hich\af2\dbch\af31505\loch\f2 e information (i.e., Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
 \par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter adds an extra section to the report.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -712,13 +735,13 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script to run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e., Domain
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve\hich\af2\dbch\af31505\loch\f2  hardware information (i.e., Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
 \par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabl\hich\af2\dbch\af31505\loch\f2 ed by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -726,33 +749,34 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -IncludeUserInfo [<S\hich\af2\dbch\af31505\loch\f2 witchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -IncludeUserInfo [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         For the User Miscellaneous Data section outputs a table with the SamAccountName
 \par \hich\af2\dbch\af31505\loch\f2         and DistinguishedName of the users in the All Users counts:
 \par 
 \par \hich\af2\dbch\af31505\loch\f2                 Disabled users
 \par \hich\af2\dbch\af31505\loch\f2                 Unknown users
-\par \hich\af2\dbch\af31505\loch\f2                 Locke\hich\af2\dbch\af31505\loch\f2 d out users
-\par \hich\af2\dbch\af31505\loch\f2                 All users with password expired
+\par \hich\af2\dbch\af31505\loch\f2                 Locked out users
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             All users with password expired
 \par \hich\af2\dbch\af31505\loch\f2                 All users whose password never expires
 \par \hich\af2\dbch\af31505\loch\f2                 All users with password not required
 \par \hich\af2\dbch\af31505\loch\f2                 All users who cannot change password
-\par \hich\af2\dbch\af31505\loch\f2                 All users with SID \hich\af2\dbch\af31505\loch\f2 History
-\par \hich\af2\dbch\af31505\loch\f2                 All users with Homedrive set in ADUC
+\par \hich\af2\dbch\af31505\loch\f2                 All users with SID History
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2         All users with Homedrive set in ADUC
 \par \hich\af2\dbch\af31505\loch\f2                 All users whose Primary Group is not Domain Users
 \par \hich\af2\dbch\af31505\loch\f2                 All users with RDS HomeDrive set in ADUC
-\par \hich\af2\dbch\af31505\loch\f2                 All Names in the ForeignSecurityPrincipals container that are orphan SIDs (Root domain only)
+\par \hich\af2\dbch\af31505\loch\f2                 All Names in the ForeignSecurityPrincipals container that are orphan SID\hich\af2\dbch\af31505\loch\f2 s }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 
+\par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 (Root domain only)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The Text output option is limited to the first 25 characters of the SamAccountName
-\par \hich\af2\dbch\af31505\loch\f2         and the first 116 characters of the Distinguish\hich\af2\dbch\af31505\loch\f2 edName.
+\par \hich\af2\dbch\af31505\loch\f2         and the first 116 characters of the DistinguishedName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of IU.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an al\hich\af2\dbch\af31505\loch\f2 ias of IU.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inp\hich\af2\dbch\af31505\loch\f2 ut?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Section <String[]>
@@ -760,7 +784,7 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2         Valid options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Forest
 \par \hich\af2\dbch\af31505\loch\f2                 Sites
-\par \hich\af2\dbch\af31505\loch\f2                 Domains (includes Domain Contr\hich\af2\dbch\af31505\loch\f2 ollers and optional Hardware, Services and
+\par \hich\af2\dbch\af31505\loch\f2                 Domains (includes Domain Controllers and optio\hich\af2\dbch\af31505\loch\f2 nal Hardware, Services and
 \par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo)
 \par \hich\af2\dbch\af31505\loch\f2                 OUs (Organizational Units)
 \par \hich\af2\dbch\af31505\loch\f2                 Groups
@@ -768,24 +792,24 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2                 Misc (Miscellaneous data)
 \par \hich\af2\dbch\af31505\loch\f2                 All
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to A\hich\af2\dbch\af31505\loch\f2 ll sections.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to All sections.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Multiple sections are separated by a comma. -Section forest, domains
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Multiple sections are separated by a comma. -Section forest, domains
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                All
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Ac\hich\af2\dbch\af31505\loch\f2 cept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Services [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gather information on all services running on domain controllers.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Services th\hich\af2\dbch\af31505\loch\f2 at are configured to automatically start but are not running will be
+\par \hich\af2\dbch\af31505\loch\f2         Services that are configured to automatically start but are not running will be
 \par \hich\af2\dbch\af31505\loch\f2         colored in red.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve service information (i.\hich\af2\dbch\af31505\loch\f2 e. Domain
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve serv\hich\af2\dbch\af31505\loch\f2 ice information (i.e. Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
@@ -794,7 +818,7 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -802,71 +826,71 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Microsoft Word is no longer the default report format.
+\par \hich\af2\dbch\af31505\loch\f2         Microsoft Word is\hich\af2\dbch\af31505\loch\f2  no longer the default report format.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept p\hich\af2\dbch\af31505\loch\f2 ipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger t\hich\af2\dbch\af31505\loch\f2 han the DOCX file.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microso\hich\af2\dbch\af31505\loch\f2 ft Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses Word's SaveAs PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                F\hich\af2\dbch\af31505\loch\f2 alse
+\par \hich\af2\dbch\af31505\loch\f2         Position?     \hich\af2\dbch\af31505\loch\f2                named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the\hich\af2\dbch\af31505\loch\f2  Address field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Wor\hich\af2\dbch\af31505\loch\f2 d 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/201\hich\af2\dbch\af31505\loch\f2 6)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the \hich\af2\dbch\af31505\loch\f2 MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipel\hich\af2\dbch\af31505\loch\f2 ine input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard cha\hich\af2\dbch\af31505\loch\f2 racters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
-\par \hich\af2\dbch\af31505\loch\f2                 Fa\hich\af2\dbch\af31505\loch\f2 cet (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is on\hich\af2\dbch\af31505\loch\f2 ly valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax fi\hich\af2\dbch\af31505\loch\f2 eld.
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
@@ -876,25 +900,25 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Positi\hich\af2\dbch\af31505\loch\f2 on?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for \hich\af2\dbch\af31505\loch\f2 the Cover Page if the Cover Page has the Phone field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page if the Cover Page has the Phone field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      The following Cover Pages have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline\hich\af2\dbch\af31505\loch\f2  input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
@@ -902,49 +926,49 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013, and 2016 are supported.
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Valid input is\hich\af2\dbch\af31505\loch\f2 :
+\par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't\hich\af2\dbch\af31505\loch\f2  work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
-\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  works in 2010 but Subtitle/Subject & Author fields need to be moved
-\par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
+\par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
+\par \hich\af2\dbch\af31505\loch\f2                 aft\hich\af2\dbch\af31505\loch\f2 er title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if y\hich\af2\dbch\af31505\loch\f2 ou like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (\hich\af2\dbch\af31505\loch\f2 Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 poin\hich\af2\dbch\af31505\loch\f2 t)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually chan\hich\af2\dbch\af31505\loch\f2 ged to
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; bo\hich\af2\dbch\af31505\loch\f2 x needs to be manually
-\par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
+\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       resized or font changed to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, wo\hich\af2\dbch\af31505\loch\f2 rks in
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless change\hich\af2\dbch\af31505\loch\f2 d to 26 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Tr\hich\af2\dbch\af31505\loch\f2 anscend (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSW\hich\af2\dbch\af31505\loch\f2 ORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -956,24 +980,24 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
 \par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid wi\hich\af2\dbch\af31505\loch\f2 th the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters\hich\af2\dbch\af31505\loch\f2 ?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port for the SmtpServer.
+\par \hich\af2\dbch\af31505\loch\f2         Spec\hich\af2\dbch\af31505\loch\f2 ifies the SMTP port for the SmtpServer.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
-\par \hich\af2\dbch\af31505\loch\f2         Accept pi\hich\af2\dbch\af31505\loch\f2 peline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wil\hich\af2\dbch\af31505\loch\f2 dcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report(s).
@@ -988,14 +1012,14 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SuperVerbose [<SwitchParameter>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?     \hich\af2\dbch\af31505\loch\f2                false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From\hich\af2\dbch\af31505\loch\f2  email address.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or To are used, this is a required parameter.
 \par 
@@ -1003,53 +1027,54 @@ oad/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wild\hich\af2\dbch\af31505\loch\f2 card characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   If SmtpServer or From are used, this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or From are used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fal\hich\af2\dbch\af31505\loch\f2 se
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to \hich\af2\dbch\af31505\loch\f2 use SSL for the SmtpServer.
 \par \hich\af2\dbch\af31505\loch\f2         The default is False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard c\hich\af2\dbch\af31505\loch\f2 haracters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-\par \hich\af2\dbch\af31505\loch\f2         OutBu\hich\af2\dbch\af31505\loch\f2 ffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, se\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030c007f0000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 
-https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 ).
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
-\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this\hich\af2\dbch\af31505\loch\f2  script.  This script creates a Word or PDF document.
+\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a Word or PDF document.
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: ADDS_Inventory_V3.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11867194 \hich\af2\dbch\af31505\loch\f2 6}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.07
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and Michael B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: July }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid208880 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4269799 \hich\af2\dbch\af31505\loch\f2 7}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 , 2021
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: August 31, 2021
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -1060,9 +1085,9 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain cont\hich\af2\dbch\af31505\loch\f2 roller that is also a global catalog server and use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2  that as the
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as\hich\af2\dbch\af31505\loch\f2  the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par 
 \par 
 \par 
 \par 
@@ -1076,22 +1101,26 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Car\hich\af2\dbch\af31505\loch\f2 l Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries f\hich\af2\dbch\af31505\loch\f2 or
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller th\hich\af2\dbch\af31505\loch\f2 at is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
+\par 
+\par 
+\par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Cre\hich\af2\dbch\af31505\loch\f2 ates an HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  company.tld for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
@@ -1102,14 +1131,13 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADDomain}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 child.company.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADDomain child.company.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     child.company.tld for the AD Domain.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName \hich\af2\dbch\af31505\loch\f2 defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $\hich\af2\dbch\af31505\loch\f2 Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
@@ -1118,8 +1146,8 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest parent.company.tld -ADDomain}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 \hich\af2\dbch\af31505\loch\f2      
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 child.company.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS\hich\af2\dbch\af31505\loch\f2 _Inventory_V3.ps1 -ADForest parent.company.tld -ADDomain
+\par \hich\af2\dbch\af31505\loch\f2     child.company.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
@@ -1135,25 +1163,25 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 ------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -Comput\hich\af2\dbch\af31505\loch\f2 erName DC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -ComputerName DC01
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Soft\hich\af2\dbch\af31505\loch\f2 ware\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Co\hich\af2\dbch\af31505\loch\f2 mpany="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Co\hich\af2\dbch\af31505\loch\f2 ver Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script runs remotely on the DC01 domain c\hich\af2\dbch\af31505\loch\f2 ontroller.
+\par \hich\af2\dbch\af31505\loch\f2     The script runs remotely on the DC01 domain controller.
 \par 
 \par 
 \par 
@@ -1162,19 +1190,19 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Uses all default values and\hich\af2\dbch\af31505\loch\f2  saves the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page forma\hich\af2\dbch\af31505\loch\f2 t.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a \hich\af2\dbch\af31505\loch\f2 domain controller that is also a global catalog server and uses that as the value
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the\hich\af2\dbch\af31505\loch\f2  value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
 \par 
@@ -1182,13 +1210,13 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Text -ADForest corp.carlwebster.co\hich\af2\dbch\af31505\loch\f2 m
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Text -ADForest corp.carlwebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as a formatted text file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USER\hich\af2\dbch\af31505\loch\f2 DNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
@@ -1197,14 +1225,14 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -HTML -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Invento\hich\af2\dbch\af31505\loch\f2 ry_V3.ps1 -HTML -ADForest corp.carlwebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as an HTML file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $\hich\af2\dbch\af31505\loch\f2 Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 a domain controller that is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
 \par 
@@ -1212,7 +1240,7 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\ADDS_Inventory_V3.ps1 -hardware
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -hardware
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
@@ -1221,7 +1249,7 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Compute\hich\af2\dbch\af31505\loch\f2 rName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
@@ -1234,11 +1262,10 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and add additional information for the services running }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 on}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 each domain controller.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and add additional information for the services running
+\par \hich\af2\dbch\af31505\loch\f2     on each domain controller.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:U\hich\af2\dbch\af31505\loch\f2 SERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value \hich\af2\dbch\af31505\loch\f2 of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
@@ -1247,21 +1274,21 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 12 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -DCDNSInfo
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an H\hich\af2\dbch\af31505\loch\f2 TML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values and adds additional information for each domain controller about
-\par \hich\af2\dbch\af31505\loch\f2     its DNS IP con\hich\af2\dbch\af31505\loch\f2 figuration.
+\par \hich\af2\dbch\af31505\loch\f2     its DNS IP configuration.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     An extra section is added to the end of the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also \hich\af2\dbch\af31505\loch\f2 a global catalog server and uses that as the value
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
 \par 
@@ -1270,14 +1297,14 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPa\hich\af2\dbch\af31505\loch\f2 ge "Mod" -UserName "Carl Webster" -ComputerName ADDC01
+\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage "Mod" -UserName "Carl Webster" -ComputerName ADDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the Us\hich\af2\dbch\af31505\loch\f2 er Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
@@ -1288,20 +1315,20 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript\hich\af2\dbch\af31505\loch\f2  .\\ADDS_Inventory_V3.ps1 -MSWord -CN "Carl Webster Consulting"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWor\hich\af2\dbch\af31505\loch\f2 d -CN "Carl Webster Consulting"
 \par \hich\af2\dbch\af31505\loch\f2     -CP "Mod" -UN "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
-\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (ali\hich\af2\dbch\af31505\loch\f2 as CP).
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerNam\hich\af2\dbch\af31505\loch\f2 e defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog s\hich\af2\dbch\af31505\loch\f2 erver and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
 \par 
@@ -1310,22 +1337,22 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
-\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2     Street, London, England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44\hich\af2\dbch\af31505\loch\f2  1753 276200
+\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Exposure -U\hich\af2\dbch\af31505\loch\f2 serName "Dr. Watson" -CompanyAddress "221B Baker}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 
+\par \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2    Street, London, England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Exposure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the \hich\af2\dbch\af31505\loch\f2 Company Address.
+\par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2     ADForest defa\hich\af2\dbch\af31505\loch\f2 ults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries f\hich\af2\dbch\af31505\loch\f2 or
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
@@ -1334,21 +1361,21 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "\hich\af2\dbch\af31505\loch\f2 Sherlock Holmes
 \par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Facet -UserName "Dr. Watson" -CompanyEmail
 \par \hich\af2\dbch\af31505\loch\f2     SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for\hich\af2\dbch\af31505\loch\f2  the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Facet for the Co\hich\af2\dbch\af31505\loch\f2 ver Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the val\hich\af2\dbch\af31505\loch\f2 ue of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script q\hich\af2\dbch\af31505\loch\f2 ueries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
@@ -1357,18 +1384,18 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript\hich\af2\dbch\af31505\loch\f2  >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -AddDateTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of\hich\af2\dbch\af31505\loch\f2  $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yy\hich\af2\dbch\af31505\loch\f2 yy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 2021-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2     The output filename is company.tld_2021-06-01_1800.docx.
 \par 
@@ -1377,34 +1404,34 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -PDF -ADForest cor\hich\af2\dbch\af31505\loch\f2 p.carlwebster.com
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as a PDF file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRE\hich\af2\dbch\af31505\loch\f2 NT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the va\hich\af2\dbch\af31505\loch\f2 lue
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a gl\hich\af2\dbch\af31505\loch\f2 obal catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 2021-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     The output filename is corp.carlwebster.com_2021-06-01_1800.PDF
+\par \hich\af2\dbch\af31505\loch\f2     The output filename is corp\hich\af2\dbch\af31505\loch\f2 .carlwebster.com_2021-06-01_1800.PDF
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   -------------------------- EXAMPLE 19 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest corp.carlwebster.com -Folder
 \par \hich\af2\dbch\af31505\loch\f2     \\\\FileServer\\ShareName
@@ -1413,28 +1440,29 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
-\par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The output file is saved in the path \\\\FileServer\\ShareName.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 -------------------------- EXAMPLE 20 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Section Forest
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to th\hich\af2\dbch\af31505\loch\f2 e value of $Env:USERDNSDOMAIN
+\par \hich\af2\dbch\af31505\loch\f2     ADFo\hich\af2\dbch\af31505\loch\f2 rest defaults to the value of $Env:USERDNSDOMAIN
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The report includes \hich\af2\dbch\af31505\loch\f2 only the Forest section.
+\par \hich\af2\dbch\af31505\loch\f2     T\hich\af2\dbch\af31505\loch\f2 he report includes only the Forest section.
 \par 
 \par 
 \par 
@@ -1444,26 +1472,26 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Section groups, misc -ADForest
 \par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com -ServerName PrimaryDC.websterslab.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML re\hich\af2\dbch\af31505\loch\f2 port.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com for ADForest.
 \par \hich\af2\dbch\af31505\loch\f2     PrimaryDC.websterslab.com for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The report includes only the Groups and Miscellaneous sections.
+\par \hich\af2\dbch\af31505\loch\f2     The \hich\af2\dbch\af31505\loch\f2 report includes only the Groups and Miscellaneous sections.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 -------------------------- EXAMPLE 22 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -MaxDetails
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
+\par \hich\af2\dbch\af31505\loch\f2     Set the following parameter valu\hich\af2\dbch\af31505\loch\f2 es:
 \par \hich\af2\dbch\af31505\loch\f2         DCDNSInfo       = True
 \par \hich\af2\dbch\af31505\loch\f2         GPOInheritance  = True
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Hardware        = True
+\par \hich\af2\dbch\af31505\loch\f2         Hardware        = True
 \par \hich\af2\dbch\af31505\loch\f2         IncludeUserInfo = True
 \par \hich\af2\dbch\af31505\loch\f2         Services        = True
 \par 
@@ -1474,53 +1502,52 @@ https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefau
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -SmtpServer mail.domain.tld -From
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer mail.domain.tld -From
 \par \hich\af2\dbch\af31505\loch\f2     ADAdmin@domain.tld -To ITGroup@domain.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mail.domain.tld, sending from ADAdmin@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mail.domain.tld, sendin\hich\af2\dbch\af31505\loch\f2 g from ADAdmin@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     and sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the def\hich\af2\dbch\af31505\loch\f2 ault SMTP port 25 and does not use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts
-\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid crede\hich\af2\dbch\af31505\loch\f2 ntials.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\P\hich\af2\dbch\af31505\loch\f2 SScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer mailrelay.domain.tld -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer mailrelay.domain.tld -From
 \par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mailrelay.domain.tld, sending from
-\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.\hich\af2\dbch\af31505\loch\f2 tld and sending to ITGroup@domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld and sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send an unauthenticated email using an email relay server requires the From email
+\par \hich\af2\dbch\af31505\loch\f2     To send an unauthenticated email using an email relay server requires the From\hich\af2\dbch\af31505\loch\f2  email
 \par \hich\af2\dbch\af31505\loch\f2     account to use the name Anonymous.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid1778922 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/2956491?hl=en"
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030040000002}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 
-https://support.google.com/a/ans\hich\af2\dbch\af31505\loch\f2 wer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid1778922 {\*\datafield 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en"
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006e0137f6}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 
-https://support.google.com/a/answer/176600?hl=e\hich\af2\dbch\af31505\loch\f2 n}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the "Less
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, secure password for the anonymous@domai\hich\af2\dbch\af31505\loch\f2 n.tld
+\par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, secure password for the anonymous@domain.tl\hich\af2\dbch\af31505\loch\f2 d
 \par \hich\af2\dbch\af31505\loch\f2     account.
 \par 
 \par 
@@ -1529,62 +1556,61 @@ https://support.google.com/a/answer/176600?hl=e\hich\af2\dbch\af31505\loch\f2 n}
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
-\par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITG\hich\af2\dbch\af31505\loch\f2 roupDL@labaddomain.com
+\par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 \hich\af2\dbch\af31505\loch\f2  H\hich\af2\dbch\af31505\loch\f2 
-YPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 
+{\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900460075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00037f001e3094}}}{\fldrslt {
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid1778922\charrsid1778922 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email
-\hich\af2\dbch\af31505\loch\f2 -using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922\charrsid1778922 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunc\hich\af2\dbch\af31505\loch\f2 
+tion-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server labaddomain-com.mail.protection.outlook.com, sending
-\par \hich\af2\dbch\af31505\loch\f2     from SomeEmailAddress@labaddomain.com and sending to ITGroupDL@labaddomain.com.
+\par \hich\af2\dbch\af31505\loch\f2     from SomeEmailAddress@labaddom\hich\af2\dbch\af31505\loch\f2 ain.com and sending to ITGroupDL@labaddomain.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and SSL.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------\hich\af2\dbch\af31505\loch\f2 ------- EXAMPLE 26 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer smtp.office365.com -S\hich\af2\dbch\af31505\loch\f2 mtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.office3\hich\af2\dbch\af31505\loch\f2 65.com on port 587 using SSL, sending from
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.office365.com on port 587 using SSL, sending from
 \par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com and sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts
+\par \hich\af2\dbch\af31505\loch\f2     If the \hich\af2\dbch\af31505\loch\f2 current user's credentials are not valid to send an email, the script prompts
 \par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 27 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1778922 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid1778922\charrsid1778922 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
-\par \hich\af2\dbch\af31505\loch\f2     To send an email u\hich\af2\dbch\af31505\loch\f2 sing a Gmail or g-suite account, you may have to turn ON the "Less
+\par \hich\af2\dbch\af31505\loch\f2     To send \hich\af2\dbch\af31505\loch\f2 an email using a Gmail or g-suite account, you may have to turn ON the "Less
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.gmail.com on port 587 using SSL, sending from
-\par \hich\af2\dbch\af31505\loch\f2     webster@gmail.com and sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     webster@gmail.com and \hich\af2\dbch\af31505\loch\f2 sending to ITGroup@carlwebster.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts
-\par \hich\af2\dbch\af31505\loch\f2     the user to \hich\af2\dbch\af31505\loch\f2 enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
@@ -1706,8 +1732,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000001053
-6d77d482d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000f00f
+d3ac4e9ed701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/ADDS_V3_Script_ChangeLog.txt
+++ b/ADDS_V3_Script_ChangeLog.txt
@@ -8,6 +8,21 @@
 #@essentialexch on Twitter
 #https://www.essential.exchange/blog/
 
+#Version 3.07 31-Aug-2021
+#	Add array error checking for non-empty arrays before attempting to create the Word table for most Word tables
+#	Add Function OutputReportFooter
+#	Add Parameter ReportFooter
+#		Outputs a footer section at the end of the report.
+#		Report Footer
+#			Report information:
+#				Created with: <Script Name> - Release Date: <Script Release Date>
+#				Started on <Date Time in Local Format>
+#				Elapsed time: nn days, nn hours, nn minutes, nn.nn seconds
+#				Ran from domain <Domain Name> by user <Username>
+#				Ran from the folder <Folder Name>
+#	Update Function OutputADFileLocations to better report on the SYSVOL state. Code supplied by Michael B. Smith.
+#	Update Function ProcessgGPOsByOUOld to allow Word table output to handle GPOs that somehow PowerShell thinks are arrays
+
 #Version 3.06 27-Jul-2021
 #	Add new Function ProcessOUsForBlockedInheritance to add a report section for OUs with GPO Block Inheritance set
 #	Add new Function ProcessSYSVOLStateInfo to show the SYSVOL state for each DC as an Appendix

--- a/README.md
+++ b/README.md
@@ -1,59 +1,61 @@
 # Active-Directory-V3
 Active Directory V3 Documentation Script
 
-	Creates a complete inventory of a Microsoft Active Directory Forest using Microsoft 
-	PowerShell, Word, plain text, or HTML.
-	
-	Creates a Word or PDF document, text, or HTML file named after the Active Directory 
-	Forest.
-	
-	Version 3.0 changes the default output report from Word to HTML.
-	
-	Word and PDF document includes a Cover Page, Table of Contents and Footer.
-	Includes support for the following language versions of Microsoft Word:
-		Catalan
-		Chinese
-		Danish
-		Dutch
-		English
-		Finnish
-		French
-		German
-		Norwegian
-		Portuguese
-		Spanish
-		Swedish
+    Creates a complete inventory of a Microsoft Active Directory Forest or Domain using
+    Microsoft PowerShell, Word, plain text, or HTML.
 
-	The script requires at least PowerShell version 3 but runs best in version 5.
+    Creates a Word or PDF document, text, or HTML file named after the Active Directory
+    Forest or Domain.
 
-	Word is NOT needed to run the script. This script will output in Text and HTML.
-	
-	You do NOT have to run this script on a domain controller. This script was developed 
-	and run from a Windows 10 VM.
+    Version 3.0 changes the default output report from Word to HTML.
 
-	While most of the script can be run with a non-admin account, there are some features 
-	that will not or may not work without domain admin or enterprise admin rights.  
-	The Hardware and Services parameters require domain admin privileges.  
-	
-	The script does gathering of information on Time Server and AD database, log file, and 
-	SYSVOL locations. Those require access to the registry on each domain controller, which 
-	means the script should now always be run from an elevated PowerShell session with an 
-	account with a minimum of domain admin rights.
-	
-	Running the script in a forest with multiple domains requires Enterprise Admin rights.
+    Word and PDF document includes a Cover Page, Table of Contents, and Footer.
+    Includes support for the following language versions of Microsoft Word:
+        Catalan
+        Chinese
+        Danish
+        Dutch
+        English
+        Finnish
+        French
+        German
+        Norwegian
+        Portuguese
+        Spanish
+        Swedish
 
-	The count of all users may not be accurate if the user running the script does not have 
-	the necessary permissions on all user objects.  In that case, there may be user accounts 
-	classified as "unknown".
-	
-	To run the script from a workstation, RSAT is required.
-	
-	Remote Server Administration Tools for Windows 8 
-		http://www.microsoft.com/en-us/download/details.aspx?id=28972
-		
-	Remote Server Administration Tools for Windows 8.1 
-		http://www.microsoft.com/en-us/download/details.aspx?id=39296
-		
-	Remote Server Administration Tools for Windows 10
-		http://www.microsoft.com/en-us/download/details.aspx?id=45520
-	
+    The script requires at least PowerShell version 3 but runs best in version 5.
+
+    Word is NOT needed to run the script. This script outputs in Text and HTML.
+
+    You do NOT have to run this script on a domain controller. This script was developed
+    and run from a Windows 10 VM.
+
+    While most of the script can run with a non-admin account, there are some features
+    that will not or may not work without domain admin or enterprise admin rights.
+    The Hardware and Services parameters require domain admin privileges.
+
+    The script does gathering of information on Time Server and AD database, log file, and
+    SYSVOL locations. Those require access to the registry on each domain controller, which
+    means the script should now always be run from an elevated PowerShell session with an
+    account with a minimum of domain admin rights.
+
+    Running the script in a forest with multiple domains requires Enterprise Admin rights.
+
+    The count of all users may not be accurate if the user running the script does not have
+    the necessary permissions on all user objects.  In that case, there may be user accounts
+    classified as "unknown".
+
+    To run the script from a workstation, RSAT is required.
+
+    Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)
+        https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24
+
+    Remote Server Administration Tools for Windows 8
+        https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95
+
+    Remote Server Administration Tools for Windows 8.1
+        https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226
+
+    Remote Server Administration Tools for Windows 10
+        http://www.microsoft.com/en-us/download/details.aspx?id=45520


### PR DESCRIPTION
#Version 3.07 31-Aug-2021
#	Add array error checking for non-empty arrays before attempting to create the Word table for most Word tables
#	Add Function OutputReportFooter
#	Add Parameter ReportFooter
#		Outputs a footer section at the end of the report.
#		Report Footer
#			Report information:
#				Created with: <Script Name> - Release Date: <Script Release Date>
#				Started on <Date Time in Local Format>
#				Elapsed time: nn days, nn hours, nn minutes, nn.nn seconds
#				Ran from domain <Domain Name> by user <Username>
#				Ran from the folder <Folder Name>
#	Update Function OutputADFileLocations to better report on the SYSVOL state. Code supplied by Michael B. Smith.
#	Update Function ProcessgGPOsByOUOld to allow Word table output to handle GPOs that somehow PowerShell thinks are arrays