### PR TITLE
3.08

### DIFF
--- a/ADDS_Inventory_V3.ps1
+++ b/ADDS_Inventory_V3.ps1
@@ -958,6 +958,11 @@ Param(
 #
 #Version 2.0 is based on version 1.20
 #
+#Version 3.08
+#	Update schema numbers for Exchange CUs
+#		"15334" = "Exchange 2016 CU21-CU22"
+#		"17003" = "Exchange 2019 CU10-CU11"
+#
 #Version 3.07 11-Sep-2021
 #	Added array error checking for non-empty arrays before attempting to create the Word table for most Word tables
 #	Added Function OutputReportFooter
@@ -9802,11 +9807,11 @@ Function ProcessDomains
 	"15330" = "Exchange 2016 CU6"; #added in 2.16
 	"15332" = "Exchange 2016 CU7 through CU18"; #added in 2.16 and updated in 2.20, updated in 2.22, updated in 2.24, updated in 3.02
 	"15333" = "Exchange 2016 CU19/CU20"; #added in 3.02, updated in 3.05
-	"15334" = "Exchange 2016 CU21"; #added in 3.05
+	"15334" = "Exchange 2016 CU21-CU22"; #added in 3.05, updated in 3.08
 	"17000" = "Exchange 2019 RTM/CU1"; #added in 2.22, updated in 2.24
 	"17001" = "Exchange 2019 CU2-CU7"; #added in 2.24, updated in 3.02
 	"17002" = "Exchange 2019 CU8/CU9"; #added in 3.02, updated in 3.05
-	"17003" = "Exchange 2019 CU10"; #added in 3.05
+	"17003" = "Exchange 2019 CU10-CU11"; #added in 3.05, updated in 3.08
 	}
 
 	ForEach($Domain in $Script:Domains)

--- a/ADDS_Inventory_V3_ReadMe.rtf
+++ b/ADDS_Inventory_V3_ReadMe.rtf
@@ -1,19 +1,19 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
-{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f49\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f50\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
-{\f51\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f52\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f64\fbidi \fmodern\fcharset238\fprq1 Courier New CE;}{\f65\fbidi \fmodern\fcharset204\fprq1 Courier New Cyr;}
-{\f67\fbidi \fmodern\fcharset161\fprq1 Courier New Greek;}{\f68\fbidi \fmodern\fcharset162\fprq1 Courier New Tur;}{\f69\fbidi \fmodern\fcharset177\fprq1 Courier New (Hebrew);}{\f70\fbidi \fmodern\fcharset178\fprq1 Courier New (Arabic);}
-{\f71\fbidi \fmodern\fcharset186\fprq1 Courier New Baltic;}{\f72\fbidi \fmodern\fcharset163\fprq1 Courier New (Vietnamese);}{\f384\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f385\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}
-{\f387\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f388\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f391\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f392\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}
-{\f414\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\f415\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\f417\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\f418\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}
-{\f419\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\f420\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\f421\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}{\f422\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}
-{\f474\fbidi \froman\fcharset238\fprq2 Cambria CE;}{\f475\fbidi \froman\fcharset204\fprq2 Cambria Cyr;}{\f477\fbidi \froman\fcharset161\fprq2 Cambria Greek;}{\f478\fbidi \froman\fcharset162\fprq2 Cambria Tur;}
-{\f481\fbidi \froman\fcharset186\fprq2 Cambria Baltic;}{\f482\fbidi \froman\fcharset163\fprq2 Cambria (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f46\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f47\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\f49\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f50\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f51\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f52\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
+{\f53\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f54\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f66\fbidi \fmodern\fcharset238\fprq1 Courier New CE;}{\f67\fbidi \fmodern\fcharset204\fprq1 Courier New Cyr;}
+{\f69\fbidi \fmodern\fcharset161\fprq1 Courier New Greek;}{\f70\fbidi \fmodern\fcharset162\fprq1 Courier New Tur;}{\f71\fbidi \fmodern\fcharset177\fprq1 Courier New (Hebrew);}{\f72\fbidi \fmodern\fcharset178\fprq1 Courier New (Arabic);}
+{\f73\fbidi \fmodern\fcharset186\fprq1 Courier New Baltic;}{\f74\fbidi \fmodern\fcharset163\fprq1 Courier New (Vietnamese);}{\f386\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f387\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}
+{\f389\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f390\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f393\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f394\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}
+{\f416\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\f417\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\f419\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\f420\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}
+{\f421\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\f422\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\f423\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}{\f424\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}
+{\f476\fbidi \froman\fcharset238\fprq2 Cambria CE;}{\f477\fbidi \froman\fcharset204\fprq2 Cambria Cyr;}{\f479\fbidi \froman\fcharset161\fprq2 Cambria Greek;}{\f480\fbidi \froman\fcharset162\fprq2 Cambria Tur;}
+{\f483\fbidi \froman\fcharset186\fprq2 Cambria Baltic;}{\f484\fbidi \froman\fcharset163\fprq2 Cambria (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
 {\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
 {\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
 {\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -41,66 +41,91 @@
 \s1\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink15 \sqformat 
 heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
 \sbasedon0 \snext0 \slink16 \sqformat heading 2;}{\*\cs10 \additive \ssemihidden \sunhideused \spriority1 Default Paragraph Font;}{\*
-\ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\trcbpat1\trcfpat1\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv \ql \li0\ri0\sa200\sl276\slmult1
+\ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv \ql \li0\ri0\sa200\sl276\slmult1
 \widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang1033\langfe1033\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext11 \ssemihidden \sunhideused 
 Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\kerning32\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink1 \slocked \spriority9 Heading 1 Char;}{\*\cs16 \additive \rtlch\fcs1 \ab\ai\af0\afs28 \ltrch\fcs0 
 \b\i\fs28\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \slocked \ssemihidden \spriority9 Heading 2 Char;}{\s17\ql \li720\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin720\itap0\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext17 \sqformat \spriority34 \styrsid11488686 List Paragraph;}{\*\cs18 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf2 
 \sbasedon10 \sunhideused \styrsid11488686 Hyperlink;}{\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
 \snext19 \sqformat \spriority1 \styrsid10945524 No Spacing;}{\*\cs20 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf19 \sbasedon10 \styrsid15355254 FollowedHyperlink;}{\*\cs21 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf15\chshdng0\chcfpat0\chcbpat20 
-\sbasedon10 \ssemihidden \sunhideused \styrsid15166704 Unresolved Mention;}}{\*\listtable{\list\listtemplateid645948268\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698713
-\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715
-\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703
-\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713
-\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715
-\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703
-\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713
-\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715
-\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid319386001}{\list\listtemplateid-393728524\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360
-\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
-\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 
-\fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23
-\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
-\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
-\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
-\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1724937716}{\list\listtemplateid-154213762\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
-\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698715
-\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}
-\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 
-\ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-180\li6480\lin6480 }{\listname ;}\listid1818835589}{\list\listtemplateid-183201164\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace0\levelindent0{\leveltext\leveltemplateid2071627316
-\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}
-\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }
-{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23
-\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589\listoverridecount0\ls2}
-{\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1818835589\listoverridecount9{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}
-{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat
-\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid208880\rsid407474\rsid412309\rsid667579\rsid741398\rsid817497\rsid854968\rsid880017\rsid1520287\rsid1529376\rsid1778922
-\rsid1780561\rsid2374340\rsid2638156\rsid2710199\rsid2974686\rsid3342358\rsid3477011\rsid3828116\rsid3830441\rsid4269799\rsid4281248\rsid4467197\rsid4483701\rsid4945864\rsid5315553\rsid5664192\rsid5720771\rsid5767175\rsid5849890\rsid5904556\rsid6038932
-\rsid6095241\rsid6179101\rsid6508857\rsid6508924\rsid6626993\rsid7681868\rsid7695940\rsid8013811\rsid8220290\rsid8793422\rsid9135014\rsid9243658\rsid9252303\rsid9512169\rsid9727541\rsid9838801\rsid9848053\rsid10101060\rsid10290913\rsid10902102
-\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11433897\rsid11488686\rsid11602030\rsid11867194\rsid12197314\rsid12322737\rsid12343757\rsid12588820\rsid12675704\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13511313
-\rsid13532324\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14168903\rsid14176547\rsid14242459\rsid14566444\rsid14697282\rsid14893653\rsid14952143\rsid15166704\rsid15355254\rsid15760967\rsid16005803\rsid16010693\rsid16670594}{\mmathPr
-\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo9\dy28\hr13\min10}{\version70}{\edmins699}{\nofpages24}
-{\nofwords7005}{\nofchars39935}{\nofcharsws46847}{\vern31}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\sbasedon10 \ssemihidden \sunhideused \styrsid15166704 Unresolved Mention;}{\s22\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
+\fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext22 \slink23 \styrsid6913845 header;}{\*\cs23 \additive \rtlch\fcs1 \af0\afs24 \ltrch\fcs0 \f43\fs24 \sbasedon10 \slink22 \slocked \styrsid6913845 
+Header Char;}{\s24\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
+\sbasedon0 \snext24 \slink25 \styrsid6913845 footer;}{\*\cs25 \additive \rtlch\fcs1 \af0\afs24 \ltrch\fcs0 \f43\fs24 \sbasedon10 \slink24 \slocked \styrsid6913845 Footer Char;}}{\*\listtable{\list\listtemplateid645948268\listhybrid{\listlevel\levelnfc0
+\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1
+\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid319386001}{\list\listtemplateid-393728524\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
+\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 
+\fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel
+\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0
+\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1724937716}{\list\listtemplateid-154213762\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
+\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703
+\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713
+\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715
+\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698703
+\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713
+\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715
+\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid1818835589}{\list\listtemplateid-183201164\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace0
+\levelindent0{\leveltext\leveltemplateid2071627316\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0
+{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693
+\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}
+\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }
+{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23
+\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
+\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589
+\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1818835589\listoverridecount9{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel
+\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat
+\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid208880\rsid407474\rsid412309\rsid667579\rsid741398\rsid817497\rsid854968
+\rsid880017\rsid1520287\rsid1529376\rsid1778922\rsid1780561\rsid2374340\rsid2638156\rsid2710199\rsid2974686\rsid3342358\rsid3477011\rsid3828116\rsid3830441\rsid4269799\rsid4281248\rsid4467197\rsid4483701\rsid4945864\rsid5315553\rsid5664192\rsid5720771
+\rsid5767175\rsid5849890\rsid5904556\rsid6038932\rsid6095241\rsid6179101\rsid6508857\rsid6508924\rsid6626993\rsid6913845\rsid7681868\rsid7695940\rsid8013811\rsid8220290\rsid8793422\rsid9135014\rsid9243658\rsid9252303\rsid9512169\rsid9727541\rsid9838801
+\rsid9848053\rsid10101060\rsid10290913\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11433897\rsid11488686\rsid11602030\rsid11867194\rsid12197314\rsid12322737\rsid12343757\rsid12588820\rsid12675704\rsid12792789\rsid12848963
+\rsid12856395\rsid12916989\rsid13133162\rsid13511313\rsid13532324\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14167430\rsid14168903\rsid14176547\rsid14242459\rsid14566444\rsid14697282\rsid14893653\rsid14952143\rsid15166704\rsid15355254
+\rsid15760967\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}
+{\revtim\yr2021\mo11\dy24\hr5\min1}{\version71}{\edmins706}{\nofpages24}{\nofwords7012}{\nofchars39973}{\nofcharsws46892}{\vern35}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwMqgFAAAAgoAtAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
-\pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
-\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
-{\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11602030 \hich\af43\dbch\af31505\loch\f43 Active Directory }{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 
-\b\fs28\cf21\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Version }{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11433897 \hich\af43\dbch\af31505\loch\f43 3}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11488686 
-\hich\af43\dbch\af31505\loch\f43  Documentation Script ReadMe
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwMqwFAEExmZktAAAA}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid6913845 \rtlch\fcs1 
+\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid14167430 \chftnsep 
+\par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid6913845 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid14167430 \chftnsepc 
+\par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid6913845 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid14167430 \chftnsep 
+\par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid6913845 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid14167430 \chftnsepc 
+\par }}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\headerl \ltrpar \pard\plain \ltrpar\s22\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid6913845 
+\par }}{\headerr \ltrpar \pard\plain \ltrpar\s22\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid6913845 
+\par }}{\footerl \ltrpar \pard\plain \ltrpar\s24\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid6913845 
+\par }}{\footerr \ltrpar \pard\plain \ltrpar\s24\qr \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\field{\*\fldinst {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid6913845 \hich\af43\dbch\af31505\loch\f43  PAGE   \\* MERGEFORMAT }}{\fldrslt {\rtlch\fcs1 \af0 \ltrch\fcs0 
+\lang1024\langfe1024\noproof\insrsid6913845 \hich\af43\dbch\af31505\loch\f43 2}}}\sectd \ltrsect\linex0\endnhere\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid6913845 
+\par }\pard \ltrpar\s24\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid6913845 
+\par }}{\headerf \ltrpar \pard\plain \ltrpar\s22\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid6913845 
+\par }}{\footerf \ltrpar \pard\plain \ltrpar\s24\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid6913845 
+\par }}{\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}
+{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8
+\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1
+\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs28 
+\ltrch\fcs0 \b\fs28\cf21\insrsid11602030 \hich\af43\dbch\af31505\loch\f43 Active Directory }{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Version }{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 
+\b\fs28\cf21\insrsid11433897 \hich\af43\dbch\af31505\loch\f43 3}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11488686 \hich\af43\dbch\af31505\loch\f43  Documentation Script ReadMe
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid5767175 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f31506\insrsid5767175\charrsid667579 \hich\af31506\dbch\af31505\loch\f31506 NOTE: This script requires PowerShell V3 or later.
 
@@ -257,9 +282,9 @@ Domain Controller Event Log Information}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31
 \par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid10290913\charrsid10290913 
 \par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11602030 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid11488686 
 \hich\af43\dbch\af31505\loch\f43 Prerequisites
-\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 
-Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 Active Directory}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
-\hich\af37\dbch\af31505\loch\f37 , let us ensure we have the necessary requirements.
+\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Before\hich\af37\dbch\af31505\loch\f37 
+ using PowerShell to document anything in }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 Active Directory}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 
+, let us ensure we have the}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6913845 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 requirements.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 At least one Windows Server 2008 R2 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 or later }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
@@ -271,20 +296,20 @@ t one Windows 7 SP1 or later computer with the Remote Server Administration Tool
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 
 HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100630065003500
-65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab000349320044000000009400ec00a000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab000349320044000000009400ec00a00000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Win\hich\af37\dbch\af31505\loch\f37 dows 8 is available here, }
 {\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab000388002900ff0000002e8f00000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab000388002900ff0000002e8f0000000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 R\hich\af37\dbch\af31505\loch\f37 emote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004900440000003b008faa00c600}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004900440000003b008faa00c60000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -292,7 +317,7 @@ HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12916989 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c00000065000000030200060057d100007f000000802c5b677f}}}{\fldrslt {
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c00000065000000030200060057d100007f000000802c5b677f20}}}{\fldrslt {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid13858952 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid13858952\charrsid13858952 
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
@@ -363,8 +388,8 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid10945524 \hich\af43\dbch\af31505\loch\f43 Help Text
 \par }\pard\plain \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10945524 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
 \ltrch\fcs0 \insrsid10945524 
-\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid817497 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2 C:\\PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \\\hich\af2\dbch\af31505\loch\f2 
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid6913845 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 NAME
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 \\\hich\af2\dbch\af31505\loch\f2 
 ADDS_Inventory_V3.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
@@ -372,37 +397,37 @@ ADDS_Inventory_V3.ps1
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2 C:\\PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \\\hich\af2\dbch\af31505\loch\f2 
-ADDS_Inventory_V3.ps1 [-ADDomain <String>] [-ADForest <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-MaxDetails] [-HTML] [-Text] [-AddDateTime] [-Company\hich\af2\dbch\af31505\loch\f2 
-Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-Folder <String>] [-Log] [-ScriptInfo] [-ReportFooter] [-DCDNSInfo] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid817497 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 [-GPOInheritance] [-Hardware] [-IncludeUserInfo] [-Section <String[]>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2     [-Services] [-MSWord] [-PDF] [-CompanyAddress <String>] [-CompanyEmail <String>\hich\af2\dbch\af31505\loch\f2 ] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid817497 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 [-CompanyFax <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid817497 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 <String>] [-SmtpPort <Int32>] [-SmtpServer <String>] [-SuperVerbose] [-From <String>] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid817497 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 [-To <String>] [-UseSSL] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 \\\hich\af2\dbch\af31505\loch\f2 
+ADDS_Inventory_V3.ps1 [-ADDomain <String>] [-ADForest <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-MaxDetails] [-HTML] [-Text] [-AddDateTime] [-CompanyName }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid6913845 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 <\hich\af2\dbch\af31505\loch\f2 
+String>] [-Dev] [-Folder <String>] [-Log] [-ScriptInfo] [-ReportFooter] [-DCDNSInfo] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 [-GPOInheritance] [-Hardware] [-IncludeUserInfo] [-Section <String[]>] [-Services] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid6913845 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 [-MSWord] [-PDF]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>] [-CompanyEmail <String>] [-CompanyFax }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 <S\hich\af2\dbch\af31505\loch\f2 tring>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 [-SmtpPort <Int32>] [-SmtpServer <String>] [-SuperVerbose] [-From <String>] [-To }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid6913845 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 <String>] [-UseSSL] [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates \hich\af2\dbch\af31505\loch\f2 a complete inventory of a Microsoft Active Directory Forest or Domain using
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Micros\hich\af2\dbch\af31505\loch\f2 oft Active Directory Forest or Domain using
 \par \hich\af2\dbch\af31505\loch\f2     Microsoft PowerShell, Word, plain text, or HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Word or PDF document, text, or HTML file named after the Active Directory
 \par \hich\af2\dbch\af31505\loch\f2     Forest or Domain.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Version 3.0\hich\af2\dbch\af31505\loch\f2  changes the default output report from Word to HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Version 3.0 changes the default output repo\hich\af2\dbch\af31505\loch\f2 rt from Word to HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF document includes a Cover Page, Table of Contents, and Footer.
 \par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
-\par \hich\af2\dbch\af31505\loch\f2         Danis\hich\af2\dbch\af31505\loch\f2 h
+\par \hich\af2\dbch\af31505\loch\f2         Danish
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
 \par \hich\af2\dbch\af31505\loch\f2         English
 \par \hich\af2\dbch\af31505\loch\f2         Finnish
@@ -415,65 +440,65 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script requires at least PowerShell version 3 but runs best in version 5.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script outputs in Text and HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script out\hich\af2\dbch\af31505\loch\f2 puts in Text and HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a domain controller. This script was developed
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  and run from a Windows 10 VM.
+\par \hich\af2\dbch\af31505\loch\f2     and run from a Windows 10 VM.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     While most of the script can run with a non-admin account, there are some features
-\par \hich\af2\dbch\af31505\loch\f2     that will not or may not work without domain admin or enterprise admin rights.
-\par \hich\af2\dbch\af31505\loch\f2     The Hardware and Services parameters require domai\hich\af2\dbch\af31505\loch\f2 n admin privileges.
+\par \hich\af2\dbch\af31505\loch\f2     that will not or \hich\af2\dbch\af31505\loch\f2 may not work without domain admin or enterprise admin rights.
+\par \hich\af2\dbch\af31505\loch\f2     The Hardware and Services parameters require domain admin privileges.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script does gathering of information on Time Server and AD database, log file, and
-\par \hich\af2\dbch\af31505\loch\f2     SYSVOL locations. Those require access to the registry on each domain controller, which
-\par \hich\af2\dbch\af31505\loch\f2     means the script should now always be run from a\hich\af2\dbch\af31505\loch\f2 n elevated PowerShell session with an
+\par \hich\af2\dbch\af31505\loch\f2     SYSVOL locations. Those \hich\af2\dbch\af31505\loch\f2 require access to the registry on each domain controller, which
+\par \hich\af2\dbch\af31505\loch\f2     means the script should now always be run from an elevated PowerShell session with an
 \par \hich\af2\dbch\af31505\loch\f2     account with a minimum of domain admin rights.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Running the script in a forest with multiple domains requires Enterprise Admin rights.
+\par \hich\af2\dbch\af31505\loch\f2     Running the script in a forest with multiple d\hich\af2\dbch\af31505\loch\f2 omains requires Enterprise Admin rights.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The count of all users may not be accurate if the user running the scr\hich\af2\dbch\af31505\loch\f2 ipt does not have
+\par \hich\af2\dbch\af31505\loch\f2     The count of all users may not be accurate if the user running the script does not have
 \par \hich\af2\dbch\af31505\loch\f2     the necessary permissions on all user objects.  In that case, there may be user accounts
 \par \hich\af2\dbch\af31505\loch\f2     classified as "unknown".
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To run the script from a workstation, RSAT is required.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24" }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100630065003500
-65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab00030096}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid817497\charrsid817497 
+65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\cs18\f2\fs18\ul\cf2\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6913845\charrsid6913845 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95" }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Too\hich\af2\dbch\af31505\loch\f2 ls for Windows 8
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid817497\charrsid817497 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\cs18\f2\fs18\ul\cf2\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6913845\charrsid6913845 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8.1
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226" }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "h\hich\af2\dbch\af31505\loch\f2 
+ttps://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff96}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid817497\charrsid817497 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\cs18\f2\fs18\ul\cf2\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6913845\charrsid6913845 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Wind\hich\af2\dbch\af31505\loch\f2 ows 10
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administ\hich\af2\dbch\af31505\loch\f2 ration Tools for Windows 10
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "http://www.microsoft.com/en-us/\hich\af2\dbch\af31505\loch\f2 
+download/details.aspx?id=45520"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300ae}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 
-\hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/do\hich\af2\dbch\af31505\loch\f2 wnload/details.aspx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid6913845\charrsid6913845 
+\hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
 \par \hich\af2\dbch\af31505\loch\f2     -ADDomain <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory domain object by providing one of the following
-\par \hich\af2\dbch\af31505\loch\f2         property values. The identifier in parentheses is the LDAP display name for the
-\par \hich\af2\dbch\af31505\loch\f2         attrib\hich\af2\dbch\af31505\loch\f2 ute. All values are for the domainDNS object that represents the domain.
+\par \hich\af2\dbch\af31505\loch\f2         property values. The identif\hich\af2\dbch\af31505\loch\f2 ier in parentheses is the LDAP display name for the
+\par \hich\af2\dbch\af31505\loch\f2         attribute. All values are for the domainDNS object that represents the domain.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Distinguished Name
 \par 
@@ -481,7 +506,7 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         GUID (objectGUID)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Example: b147a813-9938-4a89-bc93-58a0d36c41c3
+\par \hich\af2\dbch\af31505\loch\f2         Example: b147\hich\af2\dbch\af31505\loch\f2 a813-9938-4a89-bc93-58a0d36c41c3
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Security Identifier (objectSid)
 \par 
@@ -493,22 +518,22 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NetBIOS domain name
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Examp\hich\af2\dbch\af31505\loch\f2 le: labaddomain
+\par \hich\af2\dbch\af31505\loch\f2         Example: labaddomain
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If both ADForest and ADDomain are specified, ADDomain takes precedence.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       \hich\af2\dbch\af31505\loch\f2 false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ADForest <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory forest object by providing one of the following
 \par \hich\af2\dbch\af31505\loch\f2         attribute values.
-\par \hich\af2\dbch\af31505\loch\f2         The identifier in parentheses is the LDAP display name for the attribute.
+\par \hich\af2\dbch\af31505\loch\f2         The identifier in parentheses is the LDAP display name for the \hich\af2\dbch\af31505\loch\f2 attribute.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Fully qualified domain name
+\par \hich\af2\dbch\af31505\loch\f2         Fully qualified domain name
 \par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2         GUID (objectGUID)
 \par \hich\af2\dbch\af31505\loch\f2                 Example: b147a813-9938-4a89-bc93-58a0d36c41c3
@@ -550,23 +575,23 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is the same as using the following parameters:
 \par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo
-\par \hich\af2\dbch\af31505\loch\f2                 GPOInheritance
-\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  Hardware
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              GPOInheritance
+\par \hich\af2\dbch\af31505\loch\f2                 Hardware
 \par \hich\af2\dbch\af31505\loch\f2                 IncludeUserInfo
 \par \hich\af2\dbch\af31505\loch\f2                 Services
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extremely large report and
 \par \hich\af2\dbch\af31505\loch\f2         can take a very long time to run.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter \hich\af2\dbch\af31505\loch\f2 has an alias of MAX.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?    \hich\af2\dbch\af31505\loch\f2                 false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -HTML [<Switch\hich\af2\dbch\af31505\loch\f2 Parameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         HTML is now the default report format.
@@ -574,57 +599,57 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                  \hich\af2\dbch\af31505\loch\f2   named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is \hich\af2\dbch\af31505\loch\f2 disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    n\hich\af2\dbch\af31505\loch\f2 amed
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [\hich\af2\dbch\af31505\loch\f2 <SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date timestamp to the end of the file name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The timestamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2         June 1, 2021 at 6PM is 2021-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         The timestamp is\hich\af2\dbch\af31505\loch\f2  in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2         June 1, 2022 at 6PM is 2022-06-01_1800.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2021-06-01_1800.docx (or .pdf).
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2022-06-01_1800.docx (or .pdf).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fa\hich\af2\dbch\af31505\loch\f2 lse
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Word Cover Page or the Forest Information section for
-\par \hich\af2\dbch\af31505\loch\f2         HTML\hich\af2\dbch\af31505\loch\f2  and Text.
+\par \hich\af2\dbch\af31505\loch\f2         HTML and Text.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Default value for Word output is contained in
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\C\hich\af2\dbch\af31505\loch\f2 ompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
-\par \hich\af2\dbch\af31505\loch\f2         on the computer running\hich\af2\dbch\af31505\loch\f2  the script.
+\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         For Word output, if either registry key does not exist and this parameter is not
+\par \hich\af2\dbch\af31505\loch\f2         For Word output, if either registry key does not exist an\hich\af2\dbch\af31505\loch\f2 d this parameter is not
 \par \hich\af2\dbch\af31505\loch\f2         specified, the report does not contain a Company Name on the cover page.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         For HTML and Text o\hich\af2\dbch\af31505\loch\f2 utput, the Forest Information section does not contain the Company
+\par \hich\af2\dbch\af31505\loch\f2         For HTML and Text output, the Forest Information section does not contain the Company
 \par \hich\af2\dbch\af31505\loch\f2         Name if this parameter is not specified.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -634,24 +659,24 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
 \par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is u\hich\af2\dbch\af31505\loch\f2 sed when the script developer requests more troubleshooting data.
-\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script runs.
+\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder\hich\af2\dbch\af31505\loch\f2  from where the script runs.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept p\hich\af2\dbch\af31505\loch\f2 ipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
@@ -661,57 +686,58 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard character\hich\af2\dbch\af31505\loch\f2 s?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to\hich\af2\dbch\af31505\loch\f2  a text file.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script runs.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This paramete\hich\af2\dbch\af31505\loch\f2 r has an alias of SI.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?           \hich\af2\dbch\af31505\loch\f2          named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -ReportFooter [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Outputs a footer section at the end of the report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This \hich\af2\dbch\af31505\loch\f2 parameter has an alias of RF.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Report Footer
+\par \hich\af2\dbch\af31505\loch\f2                 Report information:
+\par \hich\af2\dbch\af31505\loch\f2                         Created with: <Script Name> - Release Date: <Script Release Date>
+\par \hich\af2\dbch\af31505\loch\f2                         Script version: <Script Version>
+\par \hich\af2\dbch\af31505\loch\f2                         Started on <Date Time in Local Format>
+\par \hich\af2\dbch\af31505\loch\f2                         Elapsed time: nn days, nn hours, nn minutes, nn.nn seconds
+\par \hich\af2\dbch\af31505\loch\f2                         Ran from domain <Domain Name> by user <Username>
+\par \hich\af2\dbch\af31505\loch\f2                         Ran from the \hich\af2\dbch\af31505\loch\f2 folder <Folder Name>
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Script Name and Script Release date are script-specific variables.
+\par \hich\af2\dbch\af31505\loch\f2         Start Date Time in Local Format is a script variable.
+\par \hich\af2\dbch\af31505\loch\f2         Elapsed time is a calculated value.
+\par \hich\af2\dbch\af31505\loch\f2         Domain Name is $env:USERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2         Us\hich\af2\dbch\af31505\loch\f2 ername is $env:USERNAME.
+\par \hich\af2\dbch\af31505\loch\f2         Folder Name is a script variable.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -ReportFooter\hich\af2\dbch\af31505\loch\f2  [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Outputs a footer section at the end of the report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of RF.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Report Footer
-\par \hich\af2\dbch\af31505\loch\f2                 Report information:
-\par \hich\af2\dbch\af31505\loch\f2                         Created with: <Script Name> - Release Date: <Script Release Date>
-\par \hich\af2\dbch\af31505\loch\f2                         Started on <Date Time in Local Format>
-\par \hich\af2\dbch\af31505\loch\f2                         Elapsed time: nn days, nn hours, nn minutes, nn.nn seconds
-\par \hich\af2\dbch\af31505\loch\f2                     \hich\af2\dbch\af31505\loch\f2     Ran from domain <Domain Name> by user <Username>
-\par \hich\af2\dbch\af31505\loch\f2                         Ran from the folder <Folder Name>
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Script Name and Script Release date are script-specific variables.
-\par \hich\af2\dbch\af31505\loch\f2         Start Date Time in Local Format is a script variable.
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Elapsed time is a calulated value.
-\par \hich\af2\dbch\af31505\loch\f2         Domain Name is $env:USERDNSDOMAIN.
-\par \hich\af2\dbch\af31505\loch\f2         Username is $env:USERNAME.
-\par \hich\af2\dbch\af31505\loch\f2         Folder Name is a script variable.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Defau\hich\af2\dbch\af31505\loch\f2 lt value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept w\hich\af2\dbch\af31505\loch\f2 ildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -DCDNSInfo [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather, for each domain controller, the IP Address, and each DNS server
-\par \hich\af2\dbch\af31505\loch\f2         confi\hich\af2\dbch\af31505\loch\f2 gured.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script to run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         configured.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script to run from an elevated PowerShell sess\hich\af2\dbch\af31505\loch\f2 ion
 \par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e., Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter adds an extra section to t\hich\af2\dbch\af31505\loch\f2 he report.
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter adds an extra section to the report.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?             \hich\af2\dbch\af31505\loch\f2        false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -720,14 +746,14 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2     -GPOInheritance [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         In the Group Policies by OU section adds Inherited GPOs in addition to the GPOs
 \par \hich\af2\dbch\af31505\loch\f2         directly linked.
-\par \hich\af2\dbch\af31505\loch\f2         Adds a s\hich\af2\dbch\af31505\loch\f2 econd column to the table GPO Type.
+\par \hich\af2\dbch\af31505\loch\f2         Adds a second column to the table GPO Type.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of GPO.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      This parameter has an alias of GPO.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Fals\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -735,11 +761,11 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor, and
 \par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Thi\hich\af2\dbch\af31505\loch\f2 s parameter requires the script to run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e., Domain
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script to run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         usin\hich\af2\dbch\af31505\loch\f2 g an account with permission to retrieve hardware information (i.e., Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run t\hich\af2\dbch\af31505\loch\f2 he script and
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
 \par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
@@ -748,87 +774,87 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -IncludeUserInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         For the User Miscellaneous Data section outputs a table with the SamAccountNa\hich\af2\dbch\af31505\loch\f2 me
+\par \hich\af2\dbch\af31505\loch\f2         For the User Miscellaneous Data section outputs a table with the SamAccountName
 \par \hich\af2\dbch\af31505\loch\f2         and DistinguishedName of the users in the All Users counts:
 \par 
 \par \hich\af2\dbch\af31505\loch\f2                 Disabled users
-\par \hich\af2\dbch\af31505\loch\f2                 Unknown users
+\par \hich\af2\dbch\af31505\loch\f2                 Unk\hich\af2\dbch\af31505\loch\f2 nown users
 \par \hich\af2\dbch\af31505\loch\f2                 Locked out users
 \par \hich\af2\dbch\af31505\loch\f2                 All users with password expired
-\par \hich\af2\dbch\af31505\loch\f2                 All users whose password n\hich\af2\dbch\af31505\loch\f2 ever expires
+\par \hich\af2\dbch\af31505\loch\f2                 All users whose password never expires
 \par \hich\af2\dbch\af31505\loch\f2                 All users with password not required
 \par \hich\af2\dbch\af31505\loch\f2                 All users who cannot change password
-\par \hich\af2\dbch\af31505\loch\f2                 All users with SID History
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              All users with SID History
 \par \hich\af2\dbch\af31505\loch\f2                 All users with Homedrive set in ADUC
-\par \hich\af2\dbch\af31505\loch\f2                 All users whose Primary G\hich\af2\dbch\af31505\loch\f2 roup is not Domain Users
+\par \hich\af2\dbch\af31505\loch\f2                 All users whose Primary Group is not Domain Users
 \par \hich\af2\dbch\af31505\loch\f2                 All users with RDS HomeDrive set in ADUC
-\par \hich\af2\dbch\af31505\loch\f2                 All Names in the ForeignSecurityPrincipals container that are orphan SIDs }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 
-\par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 (Root domain only)
+\par \hich\af2\dbch\af31505\loch\f2                 All Names in the Foreign\hich\af2\dbch\af31505\loch\f2 SecurityPrincipals container that are orphan SIDs
+\par \hich\af2\dbch\af31505\loch\f2                 (Root domain only)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The Text output option is limited to th\hich\af2\dbch\af31505\loch\f2 e first 25 characters of the SamAccountName
+\par \hich\af2\dbch\af31505\loch\f2         The Text output option is limited to the first 25 characters of the SamAccountName
 \par \hich\af2\dbch\af31505\loch\f2         and the first 116 characters of the DistinguishedName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of IU.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?       \hich\af2\dbch\af31505\loch\f2              false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?      \hich\af2\dbch\af31505\loch\f2  false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Section <String[]>
-\par \hich\af2\dbch\af31505\loch\f2         Processes one or more sections o\hich\af2\dbch\af31505\loch\f2 f the report.
+\par \hich\af2\dbch\af31505\loch\f2         Processes one or more sections of the report.
 \par \hich\af2\dbch\af31505\loch\f2         Valid options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Forest
 \par \hich\af2\dbch\af31505\loch\f2                 Sites
-\par \hich\af2\dbch\af31505\loch\f2                 Domains (includes Domain Controllers and optional Hardware, Services and
+\par \hich\af2\dbch\af31505\loch\f2                 Domains (includes Domain Controllers an\hich\af2\dbch\af31505\loch\f2 d optional Hardware, Services and
 \par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo)
 \par \hich\af2\dbch\af31505\loch\f2                 OUs (Organizational Units)
-\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Groups
+\par \hich\af2\dbch\af31505\loch\f2                 Groups
 \par \hich\af2\dbch\af31505\loch\f2                 GPOs
 \par \hich\af2\dbch\af31505\loch\f2                 Misc (Miscellaneous data)
 \par \hich\af2\dbch\af31505\loch\f2                 All
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to All sections.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to All sectio\hich\af2\dbch\af31505\loch\f2 ns.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Multiple sections are separated by a comma. -Section forest, domains
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?               \hich\af2\dbch\af31505\loch\f2      false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                All
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Services [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gather i\hich\af2\dbch\af31505\loch\f2 nformation on all services running on domain controllers.
+\par \hich\af2\dbch\af31505\loch\f2         Gather information on all services running on domain controllers.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Services that are configured to automatically start but are not running will be
+\par \hich\af2\dbch\af31505\loch\f2         Services that are configured to automatically start \hich\af2\dbch\af31505\loch\f2 but are not running will be
 \par \hich\af2\dbch\af31505\loch\f2         colored in red.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell sessio\hich\af2\dbch\af31505\loch\f2 n
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell session
 \par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve service information (i.e. Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
+\par \hich\af2\dbch\af31505\loch\f2         Select\hich\af2\dbch\af31505\loch\f2 ing this parameter will add to both the time it takes to run the script and
 \par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabl\hich\af2\dbch\af31505\loch\f2 ed by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default v\hich\af2\dbch\af31505\loch\f2 alue                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchPara\hich\af2\dbch\af31505\loch\f2 meter>]
+\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Microsoft Word is no longer the default report format.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter\hich\af2\dbch\af31505\loch\f2  is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -839,24 +865,24 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  The PDF file is roughly 5X to 10X larger than the DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter uses Word's SaveAs PDF capability.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       This parameter uses Word's SaveAs PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?     \hich\af2\dbch\af31505\loch\f2                false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipelin\hich\af2\dbch\af31505\loch\f2 e input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Address to use fo\hich\af2\dbch\af31505\loch\f2 r the Cover Page, if the Cover Page has the Address field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
-\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
@@ -864,28 +890,28 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     ViewMaster (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
+\par \hich\af2\dbch\af31505\loch\f2         Th\hich\af2\dbch\af31505\loch\f2 is parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Defau\hich\af2\dbch\af31505\loch\f2 lt value
+\par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Em\hich\af2\dbch\af31505\loch\f2 ail field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output para\hich\af2\dbch\af31505\loch\f2 meters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    n\hich\af2\dbch\af31505\loch\f2 amed
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -895,23 +921,23 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2              \hich\af2\dbch\af31505\loch\f2    Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with th\hich\af2\dbch\af31505\loch\f2 e MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard c\hich\af2\dbch\af31505\loch\f2 haracters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page if the Cover Page has the Phone field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word \hich\af2\dbch\af31505\loch\f2 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
@@ -923,55 +949,55 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
-\par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
-\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013, and\hich\af2\dbch\af31505\loch\f2  2016 are supported.
+\par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Pag\hich\af2\dbch\af31505\loch\f2 e to use.
+\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013, and 2016 are supported.
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
-\par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2          \hich\af2\dbch\af31505\loch\f2        Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
+\par \hich\af2\dbch\af31505\loch\f2          \hich\af2\dbch\af31505\loch\f2        Austere (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
 \par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
-\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2          Conservative (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Banded (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
-\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2         Filigree (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Facet (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit;\hich\af2\dbch\af31505\loch\f2  box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Motion (Word 2010/2013/2016. Works if top date is manually changed to
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
+\par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works \hich\af2\dbch\af31505\loch\f2 but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010.\hich\af2\dbch\af31505\loch\f2  Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
 \par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2                Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Do\hich\af2\dbch\af31505\loch\f2 esn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Work\hich\af2\dbch\af31505\loch\f2 s)
+\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 V\hich\af2\dbch\af31505\loch\f2 iewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The default value is Si\hich\af2\dbch\af31505\loch\f2 deline.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Requ\hich\af2\dbch\af31505\loch\f2 ired?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -979,26 +1005,26 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:us\hich\af2\dbch\af31505\loch\f2 ername
+\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?        \hich\af2\dbch\af31505\loch\f2             false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                $e\hich\af2\dbch\af31505\loch\f2 nv:username
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port for the SmtpServer.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port for\hich\af2\dbch\af31505\loch\f2  the SmtpServer.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Pos\hich\af2\dbch\af31505\loch\f2 ition?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fals\hich\af2\dbch\af31505\loch\f2 e
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report(s).
@@ -1014,52 +1040,52 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2     -SuperVerbose [<SwitchParameter>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?     \hich\af2\dbch\af31505\loch\f2                named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or To are used, this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or T\hich\af2\dbch\af31505\loch\f2 o are used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?     \hich\af2\dbch\af31505\loch\f2                false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Specifies the username for the To email address.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or From are used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipe\hich\af2\dbch\af31505\loch\f2 line input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
-\par \hich\af2\dbch\af31505\loch\f2         The default is False.
+\par \hich\af2\dbch\af31505\loch\f2         The def\hich\af2\dbch\af31505\loch\f2 ault is False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?        \hich\af2\dbch\af31505\loch\f2             named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
-\par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2         ErrorActi\hich\af2\dbch\af31505\loch\f2 on, ErrorVariable, WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        This cmdlet supports the common parameters: Verbose, Debug,
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 ).
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 https:/go\hich\af2\dbch\af31505\loch\f2 
+.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
@@ -1073,12 +1099,11 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: ADDS_Inventory_V3.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14242459 \hich\af2\dbch\af31505\loch\f2 8}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.08
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and Michael B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9135014 \hich\af2\dbch\af31505\loch\f2 September }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14242459 \hich\af2\dbch\af31505\loch\f2 28}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9135014 \hich\af2\dbch\af31505\loch\f2 , 2021}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: November 24, 2021
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     --------\hich\af2\dbch\af31505\loch\f2 ------------------ EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1
 \par 
@@ -1086,7 +1111,7 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNS\hich\af2\dbch\af31505\loch\f2 DOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then\hich\af2\dbch\af31505\loch\f2  the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
@@ -1095,13 +1120,13 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -MSWord
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:us\hich\af2\dbch\af31505\loch\f2 ername = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Car\hich\af2\dbch\af31505\loch\f2 l Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1109,7 +1134,7 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDO\hich\af2\dbch\af31505\loch\f2 MAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the v\hich\af2\dbch\af31505\loch\f2 alue of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
@@ -1118,7 +1143,7 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3\hich\af2\dbch\af31505\loch\f2 .ps1 -ADForest company.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScrip\hich\af2\dbch\af31505\loch\f2 t >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
@@ -1148,7 +1173,8 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest parent.company.tld -ADDo\hich\af2\dbch\af31505\loch\f2 main
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest parent.company.tld -ADDo\hich\af2\dbch\af31505\loch\f2 main}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 
 \par \hich\af2\dbch\af31505\loch\f2     child.company.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
@@ -1167,19 +1193,20 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 ------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -ComputerName DC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest company.tld -ComputerName DC01}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6913845\charrsid6913845 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Softw\hich\af2\dbch\af31505\loch\f2 are\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Soft\hich\af2\dbch\af31505\loch\f2 ware\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cov\hich\af2\dbch\af31505\loch\f2 er Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Co\hich\af2\dbch\af31505\loch\f2 ver Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest
 \par 
@@ -1188,23 +1215,23 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 -------------------------- EXAMPLE 7 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Off\hich\af2\dbch\af31505\loch\f2 ice\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page forma\hich\af2\dbch\af31505\loch\f2 t.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the val\hich\af2\dbch\af31505\loch\f2 ue
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the\hich\af2\dbch\af31505\loch\f2  value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
 \par 
@@ -1218,8 +1245,8 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a glob\hich\af2\dbch\af31505\loch\f2 al catalog server and uses that as the value
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USER\hich\af2\dbch\af31505\loch\f2 DNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
 \par 
@@ -1227,14 +1254,14 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -HTML -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Invento\hich\af2\dbch\af31505\loch\f2 ry_V3.ps1 -HTML -ADForest corp.carlwebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Uses all default values and sa\hich\af2\dbch\af31505\loch\f2 ves the document as an HTML file.
+\par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as an HTML file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the valu\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 a domain controller that is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
 \par 
@@ -1251,7 +1278,7 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries\hich\af2\dbch\af31505\loch\f2  for
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
@@ -1262,7 +1289,7 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -services
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates \hich\af2\dbch\af31505\loch\f2 an HTML report.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and add additional information for the services running
 \par \hich\af2\dbch\af31505\loch\f2     on each domain controller.
@@ -1271,7 +1298,7 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
-\par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     for ComputerNam\hich\af2\dbch\af31505\loch\f2 e.
 \par 
 \par 
 \par 
@@ -1283,14 +1310,14 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values and adds additional information for each domain controller about
-\par \hich\af2\dbch\af31505\loch\f2     its DNS IP configuration.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    its DNS IP configuration.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     An extra section is added\hich\af2\dbch\af31505\loch\f2  to the end of the report.
+\par \hich\af2\dbch\af31505\loch\f2     An extra section is added to the end of the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as t\hich\af2\dbch\af31505\loch\f2 he value
+\par \hich\af2\dbch\af31505\loch\f2     a domain control\hich\af2\dbch\af31505\loch\f2 ler that is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
 \par 
@@ -1298,15 +1325,16 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Carl Webster}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6913845\charrsid6913845 
 \par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage "Mod" -UserName "Carl Webster" -ComputerName ADDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for th\hich\af2\dbch\af31505\loch\f2 e Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the Us\hich\af2\dbch\af31505\loch\f2 er Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
@@ -1315,9 +1343,10 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1\hich\af2\dbch\af31505\loch\f2 4 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWor\hich\af2\dbch\af31505\loch\f2 d -CN "Carl Webster Consulting"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CN "Carl Webster Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6913845\charrsid6913845 
 \par \hich\af2\dbch\af31505\loch\f2     -CP "Mod" -UN "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
@@ -1325,7 +1354,33 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster fo\hich\af2\dbch\af31505\loch\f2 r the User Name (alias UN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to t\hich\af2\dbch\af31505\loch\f2 he value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
+\par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>P\hich\af2\dbch\af31505\loch\f2 S C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 
+\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  
+\par \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2    Street, London, England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use:
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Addr\hich\af2\dbch\af31505\loch\f2 ess.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
@@ -1336,47 +1391,22 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
-\par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 
-\par \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2    Street, London, England" -CompanyFax "+44 1753 276600" -Com\hich\af2\dbch\af31505\loch\f2 
-panyPhone "+44 1753 276200
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, En\hich\af2\dbch\af31505\loch\f2 gland for the Company Address.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the sc\hich\af2\dbch\af31505\loch\f2 ript queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
-\par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
-\par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     --\hich\af2\dbch\af31505\loch\f2 ------------------------ EXAMPLE 16 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V3.ps1 -MSWord -CompanyName "Sherlock Holmes}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6913845\charrsid6913845 
 \par \hich\af2\dbch\af31505\loch\f2     Consulting" -CoverPage Facet -UserName "Dr. Watson" -CompanyEmail
 \par \hich\af2\dbch\af31505\loch\f2     SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Microsoft Word report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use:
+\par \hich\af2\dbch\af31505\loch\f2     W\hich\af2\dbch\af31505\loch\f2 ill use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  ADForest defaults to the value of $Env:USERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERD\hich\af2\dbch\af31505\loch\f2 NSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
@@ -1393,21 +1423,22 @@ panyPhone "+44 1753 276200
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of\hich\af2\dbch\af31505\loch\f2  $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 2021-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     The output filename is company.tld_2021-06-01_1800.docx.
+\par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yy\hich\af2\dbch\af31505\loch\f2 yy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2022 at 6PM is 2022-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     The output filename is company.tld_2022-06-01_1800.docx.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -PDF -ADForest cor\hich\af2\dbch\af31505\loch\f2 p.carlwebster.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as a PDF file.
@@ -1417,26 +1448,27 @@ panyPhone "+44 1753 276200
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebst\hich\af2\dbch\af31505\loch\f2 er.com for the AD Forest.
+\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a gl\hich\af2\dbch\af31505\loch\f2 obal catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp t\hich\af2\dbch\af31505\loch\f2 o the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 2021-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     The output filename is corp.carlwebster.com_2021-06-01_1800.PDF
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2022 at 6PM is 2022-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     The output filename is corp\hich\af2\dbch\af31505\loch\f2 .carlwebster.com_2022-06-01_1800.PDF
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest corp.carlwebster.com -Folder
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -ADForest corp.carlwebster.com -Folder}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6913845\charrsid6913845 
 \par \hich\af2\dbch\af31505\loch\f2     \\\\FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
@@ -1445,34 +1477,34 @@ panyPhone "+44 1753 276200
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
-\par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The output file is saved in the path \\\\FileServer\\S\hich\af2\dbch\af31505\loch\f2 hareName.
-\par 
-\par 
+\par \hich\af2\dbch\af31505\loch\f2     The output file is saved in the path \\\\FileServer\\ShareName.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 -------------------------- EXAMPLE 20 --------------------------
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Section Forest
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN
+\par \hich\af2\dbch\af31505\loch\f2     ADFo\hich\af2\dbch\af31505\loch\f2 rest defaults to the value of $Env:USERDNSDOMAIN
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName de\hich\af2\dbch\af31505\loch\f2 faults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the value
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The report includes only the Forest section.
+\par \hich\af2\dbch\af31505\loch\f2     T\hich\af2\dbch\af31505\loch\f2 he report includes only the Forest section.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----------------\hich\af2\dbch\af31505\loch\f2 --------- EXAMPLE 21 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Section groups, misc -ADForest
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -Section groups, misc -ADForest}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6913845\charrsid6913845 
 \par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com -ServerName PrimaryDC.websterslab.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
@@ -1480,48 +1512,50 @@ panyPhone "+44 1753 276200
 \par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com for ADForest.
 \par \hich\af2\dbch\af31505\loch\f2     PrimaryDC.websterslab.com for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The report includes only the Groups and Miscellaneous sections.
+\par \hich\af2\dbch\af31505\loch\f2     The \hich\af2\dbch\af31505\loch\f2 report includes only the Groups and Miscellaneous sections.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inve\hich\af2\dbch\af31505\loch\f2 ntory_V3.ps1 -MaxDetails
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -MaxDetails
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
+\par \hich\af2\dbch\af31505\loch\f2     Set the following parameter valu\hich\af2\dbch\af31505\loch\f2 es:
 \par \hich\af2\dbch\af31505\loch\f2         DCDNSInfo       = True
 \par \hich\af2\dbch\af31505\loch\f2         GPOInheritance  = True
 \par \hich\af2\dbch\af31505\loch\f2         Hardware        = True
 \par \hich\af2\dbch\af31505\loch\f2         IncludeUserInfo = True
 \par \hich\af2\dbch\af31505\loch\f2         Services        = True
 \par 
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Section         = "All"
+\par \hich\af2\dbch\af31505\loch\f2         Section         = "All"
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer mail.domain.tld -From
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer mail.domain.tld -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6913845\charrsid6913845 
 \par \hich\af2\dbch\af31505\loch\f2     ADAdmin@domain.tld -To ITGroup@domain.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mail.domain.tld, sending from ADAdmin@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mail.domain.tld, sendin\hich\af2\dbch\af31505\loch\f2 g from ADAdmin@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     and sending to ITGroup@domain.tld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the curr\hich\af2\dbch\af31505\loch\f2 ent user's credentials are not valid to send an email, the script prompts
-\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts
+\par \hich\af2\dbch\af31505\loch\f2     the user to enter valid crede\hich\af2\dbch\af31505\loch\f2 ntials.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer mailrelay.d\hich\af2\dbch\af31505\loch\f2 omain.tld -From
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer mailrelay.domain.tld -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6913845\charrsid6913845 
 \par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
@@ -1529,67 +1563,69 @@ panyPhone "+44 1753 276200
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mailrelay.domain.tld, sending from
 \par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld and sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send an un\hich\af2\dbch\af31505\loch\f2 authenticated email using an email relay server requires the From email
+\par \hich\af2\dbch\af31505\loch\f2     To send an unauthenticated em\hich\af2\dbch\af31505\loch\f2 ail using an email relay server requires the From email
 \par \hich\af2\dbch\af31505\loch\f2     account to use the name Anonymous.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/2956491?hl=en"
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030067}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 
-https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http\hich\af2\dbch\af31505\loch\f2 s://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://support.google.com/a/answer/176600?hl=en"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030009}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 
-https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or\hich\af2\dbch\af31505\loch\f2  g-suite account, you may have to turn ON the "Less
+\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the "Less
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, secure password for the anonymous@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     The script generates an anony\hich\af2\dbch\af31505\loch\f2 mous, secure password for the anonymous@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     account.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----------------\hich\af2\dbch\af31505\loch\f2 ---------- EXAMPLE 25 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6913845\charrsid6913845 
 \par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
 \par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Ex\hich\af2\dbch\af31505\loch\f2 ample***
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2 
- HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 
+{\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900460075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-applicatio\hich\af2\dbch\af31505\loch\f2 
-n-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid6913845\charrsid6913845 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunc\hich\af2\dbch\af31505\loch\f2 
+tion-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server labaddomain-com.mail.protection.outlook.com, sending
-\par \hich\af2\dbch\af31505\loch\f2     from SomeEmailAddress@labaddomain.com and sending to ITGroupDL@labaddomain.com.
+\par \hich\af2\dbch\af31505\loch\f2     from SomeEmailAddress@labaddom\hich\af2\dbch\af31505\loch\f2 ain.com and sending to ITGroupDL@labaddomain.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and SSL.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------\hich\af2\dbch\af31505\loch\f2 ------- EXAMPLE 26 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer smtp.office365.com -S\hich\af2\dbch\af31505\loch\f2 mtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.office3\hich\af2\dbch\af31505\loch\f2 65.com on port 587 using SSL, sending from
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.office365.com on port 587 using SSL, sending from
 \par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com and sending to ITGroup@carlwebster.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts
@@ -1598,9 +1634,10 @@ n-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\r
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 27 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpSer\hich\af2\dbch\af31505\loch\f2 ver smtp.gmail.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6913845\charrsid6913845 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
@@ -1609,10 +1646,11 @@ n-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\r
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.gmail.com on port 587 using SSL, sending from
-\par \hich\af2\dbch\af31505\loch\f2     webster@gm\hich\af2\dbch\af31505\loch\f2 ail.com and sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     webster@gmail.com and sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prom\hich\af2\dbch\af31505\loch\f2 pts
 \par \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
@@ -1734,8 +1772,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000009014
-f30e94b4d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000e0b0
+f99722e1d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/ADDS_Inventory_V3_ReadMe.rtf
+++ b/ADDS_Inventory_V3_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -89,12 +89,12 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \rsid1780561\rsid2374340\rsid2638156\rsid2710199\rsid2974686\rsid3342358\rsid3477011\rsid3828116\rsid3830441\rsid4269799\rsid4281248\rsid4467197\rsid4483701\rsid4945864\rsid5315553\rsid5664192\rsid5720771\rsid5767175\rsid5849890\rsid5904556\rsid6038932
 \rsid6095241\rsid6179101\rsid6508857\rsid6508924\rsid6626993\rsid7681868\rsid7695940\rsid8013811\rsid8220290\rsid8793422\rsid9135014\rsid9243658\rsid9252303\rsid9512169\rsid9727541\rsid9838801\rsid9848053\rsid10101060\rsid10290913\rsid10902102
 \rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11433897\rsid11488686\rsid11602030\rsid11867194\rsid12197314\rsid12322737\rsid12343757\rsid12588820\rsid12675704\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13511313
-\rsid13532324\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14168903\rsid14176547\rsid14566444\rsid14697282\rsid14893653\rsid14952143\rsid15166704\rsid15355254\rsid15760967\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0
-\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo9\dy11\hr15\min41}{\version69}{\edmins698}{\nofpages24}{\nofwords7005}
-{\nofchars39935}{\nofcharsws46847}{\vern31}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid13532324\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14168903\rsid14176547\rsid14242459\rsid14566444\rsid14697282\rsid14893653\rsid14952143\rsid15166704\rsid15355254\rsid15760967\rsid16005803\rsid16010693\rsid16670594}{\mmathPr
+\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo9\dy28\hr13\min10}{\version70}{\edmins699}{\nofpages24}
+{\nofwords7005}{\nofchars39935}{\nofcharsws46847}{\vern31}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwtKwFABAFBlMtAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwMqgFAAAAgoAtAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -271,20 +271,20 @@ t one Windows 7 SP1 or later computer with the Remote Server Administration Tool
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 
 HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100630065003500
-65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab000349320044000000009400ec00a0}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab000349320044000000009400ec00a000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Win\hich\af37\dbch\af31505\loch\f37 dows 8 is available here, }
 {\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab000388002900ff0000002e8f000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Re\hich\af37\dbch\af31505\loch\f37 mote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab000388002900ff0000002e8f00000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 R\hich\af37\dbch\af31505\loch\f37 emote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid5315553 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5315553 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004900440000003b008faa00c6}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004900440000003b008faa00c600}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -292,7 +292,7 @@ HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12916989 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c00000065000000030200060057d100007f000000802c5b67}}}{\fldrslt {
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c00000065000000030200060057d100007f000000802c5b677f}}}{\fldrslt {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid13858952 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid13858952\charrsid13858952 
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
@@ -441,7 +441,7 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100630065003500
-65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+65006500300066003100610064006100340037003200380039006300610031003400620065003500340034003800370038006100320034000000795881f43b1d7f48af2c825dc485276300000000a5ab00030096}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-sace5ee0f1ada47289ca14be544878a24}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid817497\charrsid817497 
 \par 
@@ -449,7 +449,7 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid817497\charrsid817497 
 \par 
@@ -457,23 +457,23 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff96}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid817497\charrsid817497 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows\hich\af2\dbch\af31505\loch\f2  10
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Wind\hich\af2\dbch\af31505\loch\f2 ows 10
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 
-\hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/downl\hich\af2\dbch\af31505\loch\f2 oad/details.aspx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300ae}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 
+\hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/do\hich\af2\dbch\af31505\loch\f2 wnload/details.aspx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
 \par \hich\af2\dbch\af31505\loch\f2     -ADDomain <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory domain object by providing one of the following
 \par \hich\af2\dbch\af31505\loch\f2         property values. The identifier in parentheses is the LDAP display name for the
-\par \hich\af2\dbch\af31505\loch\f2         attribute\hich\af2\dbch\af31505\loch\f2 . All values are for the domainDNS object that represents the domain.
+\par \hich\af2\dbch\af31505\loch\f2         attrib\hich\af2\dbch\af31505\loch\f2 ute. All values are for the domainDNS object that represents the domain.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Distinguished Name
 \par 
@@ -493,22 +493,22 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NetBIOS domain name
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Example: labaddomain
+\par \hich\af2\dbch\af31505\loch\f2         Examp\hich\af2\dbch\af31505\loch\f2 le: labaddomain
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         If both ADForest and ADDomain \hich\af2\dbch\af31505\loch\f2 are specified, ADDomain takes precedence.
+\par \hich\af2\dbch\af31505\loch\f2         If both ADForest and ADDomain are specified, ADDomain takes precedence.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -ADForest <Str\hich\af2\dbch\af31505\loch\f2 ing>
+\par \hich\af2\dbch\af31505\loch\f2     -ADForest <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory forest object by providing one of the following
 \par \hich\af2\dbch\af31505\loch\f2         attribute values.
 \par \hich\af2\dbch\af31505\loch\f2         The identifier in parentheses is the LDAP display name for the attribute.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Fully qualified domain name
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Fully qualified domain name
 \par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2         GUID (objectGUID)
 \par \hich\af2\dbch\af31505\loch\f2                 Example: b147a813-9938-4a89-bc93-58a0d36c41c3
@@ -517,27 +517,27 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2         NetBIOS name
 \par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain
 \par 
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Default value is $Env:USERDNSDOMAIN
+\par \hich\af2\dbch\af31505\loch\f2         Default value is $Env:USERDNSDOMAIN
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If both ADForest and ADDomain are specified, ADDomain takes precedence.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?             \hich\af2\dbch\af31505\loch\f2        false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:USERDNS\hich\af2\dbch\af31505\loch\f2 DOMAIN
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:USERDNSDOMAIN
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ComputerName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies which domain controller to use to run the script against.
-\par \hich\af2\dbch\af31505\loch\f2         If ADForest is a trusted forest, then ComputerName \hich\af2\dbch\af31505\loch\f2 is required to detect the
+\par \hich\af2\dbch\af31505\loch\f2         Specifies which domain\hich\af2\dbch\af31505\loch\f2  controller to use to run the script against.
+\par \hich\af2\dbch\af31505\loch\f2         If ADForest is a trusted forest, then ComputerName is required to detect the
 \par \hich\af2\dbch\af31505\loch\f2         existence of ADForest.
 \par \hich\af2\dbch\af31505\loch\f2         ComputerName can be entered as the NetBIOS name, FQDN, localhost, or IP Address.
-\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and used.
-\par \hich\af2\dbch\af31505\loch\f2         If entered as an IP \hich\af2\dbch\af31505\loch\f2 address, an attempt is made to determine and use the actual
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    If entered as localhost, the actual computer name is determined and used.
+\par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and use the actual
 \par \hich\af2\dbch\af31505\loch\f2         computer name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ServerName.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is $Env:USERDNSDOMAIN
+\par \hich\af2\dbch\af31505\loch\f2         Default \hich\af2\dbch\af31505\loch\f2 value is $Env:USERDNSDOMAIN
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -545,24 +545,24 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -MaxDetails [<SwitchPar\hich\af2\dbch\af31505\loch\f2 ameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -MaxDetails [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds maximum detail to the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is the same as using the following parameters:
 \par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo
 \par \hich\af2\dbch\af31505\loch\f2                 GPOInheritance
-\par \hich\af2\dbch\af31505\loch\f2                 Hardware
+\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  Hardware
 \par \hich\af2\dbch\af31505\loch\f2                 IncludeUserInfo
 \par \hich\af2\dbch\af31505\loch\f2                 Services
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      WARNING: Using this parameter can create an extremely large report and
+\par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extremely large report and
 \par \hich\af2\dbch\af31505\loch\f2         can take a very long time to run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?    \hich\af2\dbch\af31505\loch\f2                 false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -774,21 +774,21 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of IU.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?       \hich\af2\dbch\af31505\loch\f2              false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Section <String[]>
-\par \hich\af2\dbch\af31505\loch\f2         Processe\hich\af2\dbch\af31505\loch\f2 s one or more sections of the report.
+\par \hich\af2\dbch\af31505\loch\f2         Processes one or more sections o\hich\af2\dbch\af31505\loch\f2 f the report.
 \par \hich\af2\dbch\af31505\loch\f2         Valid options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Forest
 \par \hich\af2\dbch\af31505\loch\f2                 Sites
 \par \hich\af2\dbch\af31505\loch\f2                 Domains (includes Domain Controllers and optional Hardware, Services and
 \par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo)
-\par \hich\af2\dbch\af31505\loch\f2                 OUs (Organizat\hich\af2\dbch\af31505\loch\f2 ional Units)
-\par \hich\af2\dbch\af31505\loch\f2                 Groups
+\par \hich\af2\dbch\af31505\loch\f2                 OUs (Organizational Units)
+\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Groups
 \par \hich\af2\dbch\af31505\loch\f2                 GPOs
 \par \hich\af2\dbch\af31505\loch\f2                 Misc (Miscellaneous data)
 \par \hich\af2\dbch\af31505\loch\f2                 All
@@ -797,34 +797,34 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Multiple sections are separated by a comma. -Section forest, domains
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?               \hich\af2\dbch\af31505\loch\f2      false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                All
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Services [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gather information on all services running on domain controllers.
+\par \hich\af2\dbch\af31505\loch\f2         Gather i\hich\af2\dbch\af31505\loch\f2 nformation on all services running on domain controllers.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Services that are configured to automatically start but are not running will be
 \par \hich\af2\dbch\af31505\loch\f2         colored in red.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires th\hich\af2\dbch\af31505\loch\f2 e script be run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell sessio\hich\af2\dbch\af31505\loch\f2 n
 \par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve service information (i.e. Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
-\par \hich\af2\dbch\af31505\loch\f2         siz\hich\af2\dbch\af31505\loch\f2 e of the report.
+\par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabl\hich\af2\dbch\af31505\loch\f2 ed by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wil\hich\af2\dbch\af31505\loch\f2 dcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchPara\hich\af2\dbch\af31505\loch\f2 meter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Microsoft Word is no longer the default report format.
@@ -837,23 +837,23 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Sav\hich\af2\dbch\af31505\loch\f2 eAs PDF file instead of DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  The PDF file is roughly 5X to 10X larger than the DOCX file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses Word's SaveAs PDF capability.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is d\hich\af2\dbch\af31505\loch\f2 isabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?     \hich\af2\dbch\af31505\loch\f2                false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress\hich\af2\dbch\af31505\loch\f2  <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use fo\hich\af2\dbch\af31505\loch\f2 r the Cover Page, if the Cover Page has the Address field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
@@ -863,29 +863,29 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2          \hich\af2\dbch\af31505\loch\f2        Tiles (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     ViewMaster (Word 2013/2016)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Defau\hich\af2\dbch\af31505\loch\f2 lt value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  The following Cover Pages have an Email field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Em\hich\af2\dbch\af31505\loch\f2 ail field:
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    n\hich\af2\dbch\af31505\loch\f2 amed
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -1058,7 +1058,7 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
@@ -1073,11 +1073,12 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: ADDS_Inventory_V3.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.07
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 3.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14242459 \hich\af2\dbch\af31505\loch\f2 8}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and Michael B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9135014 \hich\af2\dbch\af31505\loch\f2 September 11, 2021}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9135014 \hich\af2\dbch\af31505\loch\f2 September }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14242459 \hich\af2\dbch\af31505\loch\f2 28}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9135014 \hich\af2\dbch\af31505\loch\f2 , 2021}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 1 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1
 \par 
@@ -1085,7 +1086,7 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then t\hich\af2\dbch\af31505\loch\f2 he script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNS\hich\af2\dbch\af31505\loch\f2 DOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
@@ -1187,23 +1188,23 @@ Name }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 -------------------------- EXAMPLE 7 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -PDF -ADForest corp.carlwebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Off\hich\af2\dbch\af31505\loch\f2 ice\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page forma\hich\af2\dbch\af31505\loch\f2 t.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the\hich\af2\dbch\af31505\loch\f2  value
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and uses that as the val\hich\af2\dbch\af31505\loch\f2 ue
 \par \hich\af2\dbch\af31505\loch\f2     for ComputerName.
 \par 
 \par 
@@ -1537,15 +1538,15 @@ panyPhone "+44 1753 276200
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030067}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http\hich\af2\dbch\af31505\loch\f2 s://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030009}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send an email u\hich\af2\dbch\af31505\loch\f2 sing a Gmail or g-suite account, you may have to turn ON the "Less
+\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or\hich\af2\dbch\af31505\loch\f2  g-suite account, you may have to turn ON the "Less
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
@@ -1555,21 +1556,21 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 ------------------------- EXAMPLE 25 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------------\hich\af2\dbch\af31505\loch\f2 ---------- EXAMPLE 25 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V3.ps1 -SmtpServer
 \par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
 \par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     *\hich\af2\dbch\af31505\loch\f2 **OFFICE 365 Example***
+\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Ex\hich\af2\dbch\af31505\loch\f2 ample***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 \hich\af2\dbch\af31505\loch\f2 
  HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900460075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-\hich\af2\dbch\af31505\loch\f2 
-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid817497\charrsid817497 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multiFunction-device-or-applicatio\hich\af2\dbch\af31505\loch\f2 
+n-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid817497\charrsid817497 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
@@ -1733,8 +1734,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000003049
-11574da7d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000009014
+f30e94b4d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/ADDS_V3_Script_ChangeLog.txt
+++ b/ADDS_V3_Script_ChangeLog.txt
@@ -8,6 +8,11 @@
 #@essentialexch on Twitter
 #https://www.essential.exchange/blog/
 
+#Version 3.08
+#	Update schema numbers for Exchange CUs
+#		"15334" = "Exchange 2016 CU21-CU22"
+#		"17003" = "Exchange 2019 CU10-CU11"
+
 #Version 3.07 11-Sep-2021
 #	Added array error checking for non-empty arrays before attempting to create the Word table for most Word tables
 #	Added Function OutputReportFooter

--- a/ADDS_V3_Script_ChangeLog.txt
+++ b/ADDS_V3_Script_ChangeLog.txt
@@ -8,10 +8,17 @@
 #@essentialexch on Twitter
 #https://www.essential.exchange/blog/
 
-#Version 3.08
-#	Update schema numbers for Exchange CUs
+#Version 3.08 24-Nov-2021
+#	In Function AbortScript, add test for the winword process and terminate it if it is running
+#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
+#	In Function ProcessDomainControllers, added "Computer Object DN" to the output
+#		If the DN doesn't contain "OU=Domain Controllers", highlight the Word/HTML output in red and add "***" to the text output
+#	Updated Functions ShowScriptOptions and ProcessScriptEnd to add $ReportFooter
+#	Updated schema numbers for Exchange CUs
 #		"15334" = "Exchange 2016 CU21-CU22"
 #		"17003" = "Exchange 2019 CU10-CU11"
+#	Updated the help text
+#	Updated the ReadMe file
 
 #Version 3.07 11-Sep-2021
 #	Added array error checking for non-empty arrays before attempting to create the Word table for most Word tables


### PR DESCRIPTION
#Version 3.08 24-Nov-2021
#	In Function AbortScript, add test for the winword process and terminate it if it is running
#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
#	In Function ProcessDomainControllers, added "Computer Object DN" to the output
#		If the DN doesn't contain "OU=Domain Controllers", highlight the Word/HTML output in red and add "***" to the text output
#	Updated Functions ShowScriptOptions and ProcessScriptEnd to add $ReportFooter
#	Updated schema numbers for Exchange CUs
#		"15334" = "Exchange 2016 CU21-CU22"
#		"17003" = "Exchange 2019 CU10-CU11"
#	Updated the help text
#	Updated the ReadMe file
